### PR TITLE
Add logging

### DIFF
--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -31,20 +31,27 @@ const AliasDel = class AliasDel {
             validators.type(type);
             validators.org(org);
         } catch (error) {
+            this._log.info(`alias:del - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
         const path = createFilePathToAlias({ org, type, name, alias });
         const exist = await this._exist(path);
         if (!exist) {
+            this._log.info(`alias:del - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`);
             throw new HttpError.NotFound();
         }
 
         try {
+            this._log.info(`alias:del - Start deleting alias from sink - Pathname: ${path}`);
             await this._sink.delete(path);
         } catch (error) {
+            this._log.error(`alias:del - Failed deleting alias from sink - Pathname: ${path}`);
+            this._log.trace(error);
             return new HttpError.BadGateway();
         }
+
+        this._log.info(`alias:del - Successfully deleted alias from sink - Pathname: ${path}`);
 
         const outgoing = new HttpOutgoing();
         outgoing.statusCode = 204;

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -25,6 +25,7 @@ const AliasGet = class AliasGet {
             validators.type(type);
             validators.org(org);
         } catch (error) {
+            this._log.debug(`alias:get - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
@@ -39,8 +40,11 @@ const AliasGet = class AliasGet {
             outgoing.statusCode = 303;
             outgoing.location = location;
 
+            this._log.debug(`alias:get - Alias found - Pathname: ${path}`);
+
             return outgoing;
         } catch (error) {
+            this._log.debug(`alias:get - Alias not found - Pathname: ${path}`);
             throw new HttpError.NotFound();
         }
     }

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -41,27 +41,35 @@ const AliasPost = class AliasPost {
                     try {
                         validators.version(value);
                     } catch (error) {
+                        this._log.error(`alias:post - Input field could not be validated - Name: ${name} - Value: ${value}`);
+                        this._log.trace(error);
                         busboy.destroy(new HttpError.BadRequest());
                         return;
                     }
+                    this._log.info(`alias:post - Input field added - Name: ${name} - Value: ${value}`);
                     alias.version = value;
                 }
             });
 
             busboy.on('finish', async () => {
+                this._log.info(`alias:post - Start writing alias to sink - Pathname: ${path}`);
+
                 try {
                     await utils.writeJSON(
                         this._sink,
-                        // alias.path,
                         path,
                         alias,
                         'application/json',
                     );
                 } catch (error) {
                     // TODO: Will this trigger error or is it too late to do this in the finish event??????????
+                    this._log.error(`alias:post - Failed writing alias to sink - Pathname: ${path}`);
+                    this._log.trace(error);
                     busboy.destroy(new HttpError.BadGateway());
                     return;
                 }
+
+                this._log.info(`alias:post - Successfully wrote alias to sink - Pathname: ${path}`);
 
                 const outgoing = new HttpOutgoing();
                 outgoing.mimeType = 'text/plain';
@@ -99,6 +107,7 @@ const AliasPost = class AliasPost {
             validators.type(type);
             validators.org(org);
         } catch (error) {
+            this._log.info(`alias:post - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
@@ -111,6 +120,7 @@ const AliasPost = class AliasPost {
 
         const exist = await this._exist(incoming);
         if (!exist) {
+            this._log.info(`alias:post - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`);
             throw new HttpError.NotFound();
         }
 

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -41,27 +41,35 @@ const AliasPut = class AliasPut {
                     try {
                         validators.version(value);
                     } catch (error) {
+                        this._log.error(`alias:put - Input field could not be validated - Name: ${name} - Value: ${value}`);
+                        this._log.trace(error);
                         busboy.destroy(new HttpError.BadRequest());
                         return;
                     }
+                    this._log.debug(`alias:put - Input field added - Name: ${name} - Value: ${value}`);
                     alias.version = value;
                 }
             });
 
             busboy.on('finish', async () => {
+                this._log.info(`alias:put - Start writing alias to sink - Pathname: ${path}`);
+
                 try {
                     await utils.writeJSON(
                         this._sink,
                         path,
-                        // alias.path,
                         alias,
                         'application/json',
                     );
                 } catch (error) {
                     // TODO: Will this trigger error or is it too late to do this in the finish event??????????
+                    this._log.error(`alias:put - Failed writing alias to sink - Pathname: ${path}`);
+                    this._log.trace(error);
                     busboy.destroy(new HttpError.BadGateway());
                     return;
                 }
+
+                this._log.info(`alias:put - Successfully wrote alias to sink - Pathname: ${path}`);
 
                 const outgoing = new HttpOutgoing();
                 outgoing.mimeType = 'text/plain';
@@ -99,6 +107,7 @@ const AliasPut = class AliasPut {
             validators.type(type);
             validators.org(org);
         } catch (error) {
+            this._log.info(`alias:put - Validation failed - ${error.message}`);
             throw new HttpError.BadRequest();
         }
 
@@ -111,6 +120,7 @@ const AliasPut = class AliasPut {
 
         const exist = await this._exist(incoming);
         if (exist) {
+            this._log.info(`alias:put - Alias exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`);
             throw new HttpError.Conflict();
         }
 

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -21,6 +21,7 @@ const MapGet = class MapGet {
             validators.name(name);
             validators.org(org);
         } catch (error) {
+            this._log.debug(`map:get - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
@@ -33,8 +34,11 @@ const MapGet = class MapGet {
             const stream = await this._sink.read(path);
             outgoing.stream = stream;
 
+            this._log.debug(`map:get - Import map found - Pathname: ${path}`);
+
             return outgoing;
         } catch (error) {
+            this._log.debug(`map:get - Import map not found - Pathname: ${path}`);
             throw new HttpError.NotFound();
         }
     }

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -37,6 +37,7 @@ const MapPut = class MapPut {
                 // We accept only one file on this given fieldname.
                 // Throw if any other files is posted.
                 if (fieldname !== 'map') {
+                    this._log.info(`map:put - Import map submitted on wrong field name - Field: ${fieldname}`);
                     busboy.destroy(new HttpError.BadRequest());
                     return;
                 }
@@ -48,16 +49,23 @@ const MapPut = class MapPut {
                     const str = await utils.streamCollector(file);
                     obj = JSON.parse(str);
                 } catch (error) {
+                    this._log.error(`map:put - Import map can not be parsed`);
+                    this._log.trace(error);
                     busboy.destroy(new HttpError.UnsupportedMediaType());
                     return;
                 }
 
                 // Write file to storage.
                 try {
+                    this._log.info(`map:put - Start writing import map to sink - Pathname: ${path}`);
                     await utils.writeJSON(this._sink, path, obj, 'application/json');
                 } catch (error) {
+                    this._log.error(`map:put - Failed writing import map to sink - Pathname: ${path}`);
+                    this._log.trace(error);
                     busboy.destroy(new HttpError.BadGateway());
+                    return;
                 }
+                this._log.info(`map:put - Successfully wrote import map to sink - Pathname: ${path}`);
             });
 
             busboy.on('finish', () => {
@@ -95,6 +103,7 @@ const MapPut = class MapPut {
             validators.name(name);
             validators.org(org);
         } catch (error) {
+            this._log.info(`map:put - Validation failed - ${error.message}`);
             throw new HttpError.BadRequest();
         }
 
@@ -106,6 +115,7 @@ const MapPut = class MapPut {
 
         const exist = await this._exist(incoming);
         if (exist) {
+            this._log.info(`map:put - Import map exists - Org: ${org} - Name: ${name} - Version: ${version}`);
             throw new HttpError.Conflict();
         }
 

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -23,6 +23,7 @@ const PkgGet = class PkgGet {
             validators.name(name);
             validators.org(org);
         } catch (error) {
+            this._log.debug(`pkg:get - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
@@ -42,8 +43,11 @@ const PkgGet = class PkgGet {
             const stream = await this._sink.read(path);
             outgoing.stream = stream;
 
+            this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
+
             return outgoing;
         } catch (error) {
+            this._log.debug(`pkg:get - Asset not found - Pathname: ${path}`);
             throw new HttpError.NotFound();
         }
     }

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -21,6 +21,7 @@ const PkgLog = class PkgLog {
             validators.name(name);
             validators.org(org);
         } catch (error) {
+            this._log.debug(`pkg:log - Validation failed - ${error.message}`);
             throw new HttpError.NotFound();
         }
 
@@ -33,8 +34,11 @@ const PkgLog = class PkgLog {
             const stream = await this._sink.read(path);
             outgoing.stream = stream;
 
+            this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
+
             return outgoing;
         } catch (error) {
+            this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
             throw new HttpError.NotFound();
         }
     }

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -38,17 +38,21 @@ const PkgPut = class PkgPut {
             });
 
             busboy.on('field', (name, value) => {
+                this._log.info(`pkg:put - Input field added - Name: ${name} - Value: ${value}`);
                 const promise = Promise.resolve(new Meta({ name, value }));
                 resolver.push(promise);
             });
 
-            busboy.on('file', (fieldname, file) => {
+            busboy.on('file', (fieldname, file, filename) => {
                 // We accept only one file on this given fieldname.
                 // Throw if any other files is posted.
                 if (fieldname !== 'filedata') {
+                    this._log.info(`pkg:put - Package submitted on wrong field name - Field: ${fieldname}`);
                     busboy.destroy(new HttpError.BadRequest());
                     return;
                 }
+
+                this._log.info(`pkg:put - Start extracting package - Field: ${fieldname} - Filename: ${filename}`);
 
                 const extract = new tar.Parse({
                     onentry: (entry) => {
@@ -69,15 +73,20 @@ const PkgPut = class PkgPut {
                             return;
                         }
 
+                        this._log.info(`pkg:put - Start writing asset to sink - Pathname: ${asset.pathname}`);
+
                         // eslint-disable-next-line no-async-promise-executor
                         const promise = new Promise(async (res, rej) => {
                             const path = createFilePathToAsset(asset);
                             const writer = await this._sink.write(path, asset.mimeType);
                             pipeline(entry, writer, error => {
                                 if (error) {
+                                    this._log.error(`pkg:put - Failed writing asset to sink - Pathname: ${asset.pathname}`);
+                                    this._log.trace(error);
                                     rej(error);
                                     return;
                                 }
+                                this._log.info(`pkg:put - Successfully wrote asset to sink - Pathname: ${asset.pathname}`);
                                 res(asset);
                             });
                         });
@@ -88,10 +97,12 @@ const PkgPut = class PkgPut {
 
                 pipeline(file, extract, error => {
                     if (error) {
+                        this._log.error(`pkg:put - Failed extracting package - Field: ${fieldname} - Filename: ${filename}`);
+                        this._log.trace(error);
                         busboy.destroy(new HttpError.UnsupportedMediaType());
                         return;
                     }
-                    busboy.emit('completed');
+                    busboy.emit('completed', fieldname, filename);
                 });
             });
 
@@ -99,8 +110,10 @@ const PkgPut = class PkgPut {
                 reject(error);
             });
 
-            busboy.once('completed', () => {
+            busboy.once('completed', (fieldname, filename) => {
                 Promise.all(resolver).then(assets => {
+                    this._log.info(`pkg:put - Successfully extracted package - Field: ${fieldname} - Filename: ${filename}`);
+
                     const pkg = new Package(incoming);
                     assets.forEach(obj => {
                         if (obj instanceof Asset) {
@@ -113,6 +126,9 @@ const PkgPut = class PkgPut {
                     return pkg;
                 }).then(async (pkg) => {
                     const path = createFilePathToPackage(pkg);
+
+                    this._log.info(`pkg:put - Start writing package meta file to sink - Pathname: ${path}`);
+
                     await utils.writeJSON(
                         this._sink,
                         path,
@@ -123,6 +139,8 @@ const PkgPut = class PkgPut {
                 }).then((pkg) => {
                     const pathname = createURIPathToPkgLog(pkg);
 
+                    this._log.info(`pkg:put - Successfully wrote package meta file to sink - URI: ${pathname}`);
+
                     const outgoing = new HttpOutgoing();
                     outgoing.mimeType = 'text/plain';
                     outgoing.statusCode = 303;
@@ -130,6 +148,8 @@ const PkgPut = class PkgPut {
 
                     resolve(outgoing);
                 }).catch(err => {
+                    this._log.error('pkg:put - Failed writing package meta file to sink');
+                    this._log.trace(err);
                     reject(err);
                 });
             });
@@ -157,6 +177,7 @@ const PkgPut = class PkgPut {
             validators.name(name);
             validators.org(org);
         } catch (error) {
+            this._log.info(`pkg:put - Validation failed - ${error.message}`);
             throw new HttpError.BadRequest();
         }
 
@@ -168,6 +189,7 @@ const PkgPut = class PkgPut {
 
         const exist = await this._exist(incoming);
         if (exist) {
+            this._log.info(`pkg:put - Package exists - Org: ${org} - Name: ${name} - Version: ${version}`);
             throw new HttpError.Conflict();
         }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "fastify-cors": "^2.2.0",
     "http-errors": "^1.7.3",
     "mime": "^2.4.4",
+    "pino": "^5.13.6",
+    "pino-pretty": "^3.3.0",
     "rimraf": "^3.0.0",
     "semver": "^6.3.0",
     "tar": "^5.0.5"

--- a/services/fastify.js
+++ b/services/fastify.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const fastify = require('fastify');
-const cors = require('fastify-cors');
 const abslog = require('abslog');
+const cors = require('fastify-cors');
+const pino = require('pino')({ level: 'trace', prettyPrint: true });
 const path = require('path');
+
 const { http, sink, prop } = require('../');
 
 class FastifyService {
@@ -353,7 +355,7 @@ class FastifyService {
 module.exports = FastifyService;
 
 if (require.main === module) {
-    const service = new FastifyService();
+    const service = new FastifyService({ logger: pino });
     service.start().catch(() => {
         process.exit(1);
     });


### PR DESCRIPTION
This adds logging to all handlers. All `GET` routes has most logging set to `debug` as the lowest level to minimize noise in production while all `PUT`, `POST` and `DELETE` routes has lowest level set to `info` so we can track modification on the server in production.