### PR TITLE
Change form field for tar file to be named package

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -59,7 +59,7 @@ URL parameters:
 
 Form parameters:
 
--   `:filedata` a `tar` or `tar.gz` containing the package
+-   `:package` a `tar` or `tar.gz` containing the package
 
 Status codes:
 

--- a/examples/pkg.put.js
+++ b/examples/pkg.put.js
@@ -8,7 +8,7 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 
 const formData = new FormData();
-formData.append('filedata', fs.createReadStream('../fixtures/archive.tgz'));
+formData.append('package', fs.createReadStream('../fixtures/archive.tgz'));
 
 fetch('http://localhost:4001/biz/pkg/fuzz/8.4.1', {
     method: 'PUT',

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -45,7 +45,7 @@ const PkgPut = class PkgPut {
             busboy.on('file', (fieldname, file) => {
                 // We accept only one file on this given fieldname.
                 // Throw if any other files is posted.
-                if (fieldname !== 'filedata') {
+                if (fieldname !== 'package') {
                     busboy.destroy(new HttpError.BadRequest());
                     return;
                 }

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -32,7 +32,7 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 
@@ -88,7 +88,7 @@ test('Packages PUT - all files extracted, correct response received', async t =>
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 

--- a/test/integration/pkg-put-write-integrity.js
+++ b/test/integration/pkg-put-write-integrity.js
@@ -24,7 +24,7 @@ test('Sink is slow and irregular - Writing medium sized package', async t => {
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 
@@ -131,7 +131,7 @@ test('Sink is slow and irregular - Writing small sized package', async t => {
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive-small.tgz')),
     );
 
@@ -228,7 +228,7 @@ test('Sink is slow to construct writer - Writing medium sized package', async t 
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 
@@ -335,7 +335,7 @@ test('Sink is slow to construct writer - Writing small sized package', async t =
 
     const formData = new FormData();
     formData.append(
-        'filedata',
+        'package',
         createReadStream(join(__dirname, '../../fixtures/archive-small.tgz')),
     );
 


### PR DESCRIPTION
This changes the field name of the field for the package tar file from `filedata` to `package`. Makes it a bit more intuitive. The client needs to align with this.