### PR TITLE
Make mime type detection part of the sinks

### DIFF
--- a/lib/sinks/fs.js
+++ b/lib/sinks/fs.js
@@ -2,6 +2,7 @@
 
 const { ReadFile } = require('@eik/common');
 const rimraf = require('rimraf');
+const mime = require('mime/lite');
 const path = require('path');
 const fs = require('fs');
 
@@ -88,9 +89,11 @@ const SinkFS = class SinkFS {
                         return;
                     }
 
+                    const mimeType = mime.getType(pathname) || 'application/octet-stream';
                     const etag = etagFromFsStat(stat);
 
                     const file = new ReadFile({
+                        mimeType,
                         etag,
                     });
 

--- a/lib/sinks/mem-entry.js
+++ b/lib/sinks/mem-entry.js
@@ -3,17 +3,27 @@
 const crypto = require('crypto');
 
 const Entry = class Entry {
-    constructor(payload = []) {
+    constructor({
+        mimeType = 'application/octet-stream',
+        payload = [],
+    } = {}) {
+        this._mimeType = mimeType;
         this._payload = payload;
         this._hash = '';
 
         if (Array.isArray(payload)) {
-            const hash = crypto.createHash('md5');
+            const hash = crypto.createHash('sha512');
             payload.forEach(buffer => {
                 hash.update(buffer.toString());
             });
-            this._hash = hash.digest('hex');
+            this._hash = `sha512-${hash.digest(
+                'base64',
+            )}`;
         }
+    }
+
+    get mimeType() {
+        return this._mimeType;
     }
 
     get payload() {

--- a/lib/sinks/mem.js
+++ b/lib/sinks/mem.js
@@ -3,6 +3,7 @@
 const { Writable, Readable } = require('stream');
 const { ReadFile } = require('@eik/common');
 const { join } = require('path');
+const mime = require('mime/lite');
 
 const Entry = require('./mem-entry');
 
@@ -29,16 +30,18 @@ const SinkMem = class SinkMem {
                 return;
             }
 
-            const buff = [];
+            const mimeType = mime.getType(pathname) || 'application/octet-stream';
+
+            const payload = [];
             const stream = new Writable({
                 write(chunk, encoding, cb) {
-                    buff.push(chunk);
+                    payload.push(chunk);
                     cb();
                 },
             });
 
             stream.on('finish', () => {
-                const entry = new Entry(buff);
+                const entry = new Entry({ mimeType, payload });
                 this._state.set(pathname, entry);
             });
 
@@ -57,7 +60,10 @@ const SinkMem = class SinkMem {
 
             const entry = this._state.get(pathname);
             const payload = entry.payload || [];
-            const file = new ReadFile( { etag: entry.hash });
+            const file = new ReadFile( {
+                mimeType: entry.mimeType,
+                etag: entry.hash,
+            });
 
             file.stream = new Readable({
                 read() {

--- a/lib/sinks/test.js
+++ b/lib/sinks/test.js
@@ -18,14 +18,16 @@ const SinkTest = class SinkTest {
         this._writeDelayChunks = () => -1;
     }
 
-    set(filePath, contents) {
+    set(filePath, payload) {
         const pathname = path.join(this._rootPath, filePath);
+        const mimeType = mime.getType(pathname) || 'application/octet-stream';
+
         let entry;
 
-        if (Array.isArray(contents)) {
-            entry = new Entry(contents);
+        if (Array.isArray(payload)) {
+            entry = new Entry({ mimeType, payload, });
         } else {
-            entry = new Entry([contents]);
+            entry = new Entry({ mimeType, payload: [payload], });
         }
 
         this._state.set(pathname, entry);

--- a/lib/sinks/test.js
+++ b/lib/sinks/test.js
@@ -2,6 +2,7 @@
 
 const { Writable, Readable } = require('stream');
 const { ReadFile } = require('@eik/common');
+const mime = require('mime/lite');
 const path = require('path');
 
 const Entry = require('./mem-entry');
@@ -75,8 +76,10 @@ const SinkTest = class SinkTest {
                 return;
             }
 
+            const mimeType = mime.getType(pathname) || 'application/octet-stream';
+
             const chunkDelay = this._writeDelayChunks;
-            const buff = [];
+            const payload = [];
             let count = 0;
             const stream = new Writable({
                 write(chunk, encoding, cb) {
@@ -84,11 +87,11 @@ const SinkTest = class SinkTest {
                     count += 1;
 
                     if (timeout < 0) {
-                        buff.push(chunk);
+                        payload.push(chunk);
                         cb();
                     } else {
                         setTimeout(() => {
-                            buff.push(chunk);
+                            payload.push(chunk);
                             cb();
                         }, timeout);
                     }
@@ -96,7 +99,7 @@ const SinkTest = class SinkTest {
             });
 
             stream.on('finish', () => {
-                const entry = new Entry(buff);
+                const entry = new Entry({ mimeType, payload, });
                 this._state.set(pathname, entry);
             });
 
@@ -122,7 +125,10 @@ const SinkTest = class SinkTest {
 
             const entry = this._state.get(pathname);
             const payload = entry.payload || [];
-            const file = new ReadFile( { etag: entry.hash });
+            const file = new ReadFile({
+                mimeType: entry.mimeType,
+                etag: entry.hash,
+            });
 
             file.stream = new Readable({
                 read() {

--- a/test/sinks/fs.js
+++ b/test/sinks/fs.js
@@ -101,6 +101,7 @@ test('Sink() - .read() - File exists', async (t) => {
     const readFrom = await sink.read(file);
 
     t.true(stream.isReadableStream(readFrom.stream), 'should resolve with a ReadFile object which has a .stream property');
+    t.type(readFrom.mimeType, 'string', 'should resolve with a ReadFile object which has a .mimeType property');
     t.type(readFrom.etag, 'string', 'should resolve with a ReadFile object which has a .etag property');
 
     const result = await pipeInto(readFrom.stream);
@@ -116,6 +117,46 @@ test('Sink() - .read() - File does NOT exist', (t) => {
     const sink = new Sink(DEFAULT_CONFIG);
     const dir = slug();
     t.rejects(sink.read(`/${dir}/foo/not-exist.json`), 'should reject');
+    t.end();
+});
+
+test('Sink() - .read() - value of .mimeType of known file type', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    const readFrom = await sink.read(file);
+
+    t.equal(readFrom.mimeType, 'application/json', 'should resolve with a ReadFile object which has a value for .mimeType matching the file');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .read() - value of .mimeType of unknown file type', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.foo`;
+
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    const readFrom = await sink.read(file);
+
+    t.equal(readFrom.mimeType, 'application/octet-stream', 'should resolve with a ReadFile object where .mimeType is "application/octet-stream"');
+
+    // Clean up sink
+    await sink.delete(dir);
     t.end();
 });
 

--- a/test/sinks/test.js
+++ b/test/sinks/test.js
@@ -45,7 +45,7 @@ const pipe = (...streams) => {
         });
     });
 }
-
+/*
 test('Sink() - Object type', (t) => {
     const sink = new Sink(DEFAULT_CONFIG);
     const name = Object.prototype.toString.call(sink);
@@ -273,3 +273,275 @@ test('Sink() - .exist() - directory traversal prevention', async (t) => {
     await sink.delete(dir);
     t.end();
 });
+*/
+
+
+test('Sink() - Object type', (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const name = Object.prototype.toString.call(sink);
+    t.true(name.startsWith('[object Sink'), 'should begin with Sink');
+    t.end();
+});
+
+test('Sink() - .write()', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    t.resolves(pipe(writeFrom, writeTo), 'should write file to sink');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .write() - directory traversal prevention', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+
+    t.rejects(sink.write(`../../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../../ at beginning of filepath');
+    t.rejects(sink.write(`../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../ at beginning of filepath');
+    t.rejects(sink.write(`/${dir}/../../../foo/sensitive.data`), new Error('Directory traversal'), 'should reject on path traversal in the middle of filepath');
+    t.resolves(sink.write(`./${dir}/sensitive.data`), 'should resolve on ./ at beginning of filepath');
+    t.resolves(sink.write(`/${dir}/sensitive.data`), 'should resolve on / at beginning of filepath');
+    t.resolves(sink.write(`//${dir}/sensitive.data`), 'should resolve on // at beginning of filepath');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .read() - File exists', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    const readFrom = await sink.read(file);
+
+    t.true(stream.isReadableStream(readFrom.stream), 'should resolve with a ReadFile object which has a .stream property');
+    t.type(readFrom.mimeType, 'string', 'should resolve with a ReadFile object which has a .mimeType property');
+    t.type(readFrom.etag, 'string', 'should resolve with a ReadFile object which has a .etag property');
+
+    const result = await pipeInto(readFrom.stream);
+
+    t.equal(result, FIXTURE, 'should read file from sink which equals the fixture');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .read() - File does NOT exist', (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    t.rejects(sink.read(`/${dir}/foo/not-exist.json`), 'should reject');
+    t.end();
+});
+
+test('Sink() - .read() - value of .mimeType of known file type', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    const readFrom = await sink.read(file);
+
+    t.equal(readFrom.mimeType, 'application/json', 'should resolve with a ReadFile object which has a value for .mimeType matching the file');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .read() - value of .mimeType of unknown file type', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/bar/map.foo`;
+
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    const readFrom = await sink.read(file);
+
+    t.equal(readFrom.mimeType, 'application/octet-stream', 'should resolve with a ReadFile object where .mimeType is "application/octet-stream"');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .delete() - Delete existing file', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    t.resolves(sink.exist(file), 'should resolve - file is in sink before deletion');
+
+    await sink.delete(file);
+
+    t.rejects(sink.exist(file), 'should reject - file was deleted');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .read() - directory traversal prevention', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/map.json`;
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    t.rejects(sink.read(`../../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../../ at beginning of filepath');
+    t.rejects(sink.read(`../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../ at beginning of filepath');
+    t.rejects(sink.read(`/${dir}/../../../foo/sensitive.data`), new Error('Directory traversal'), 'should reject on path traversal in the middle of filepath');
+    t.resolves(sink.read(`./${file}`), 'should resolve on ./ at beginning of filepath');
+    t.resolves(sink.read(`/${file}`), 'should resolve on / at beginning of filepath');
+    t.resolves(sink.read(`//${file}`), 'should resolve on // at beginning of filepath');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .delete() - Delete non existing file', (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    t.resolves(sink.delete('/bar/foo/not-exist.json'), 'should resolve');
+    t.end();
+});
+
+test('Sink() - .delete() - Delete file in tree structure', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const fileA = `${dir}/a/map.json`;
+    const fileB = `${dir}/b/map.json`;
+
+    const writeFromA = readFileStream('../../fixtures/import-map.json');
+    const writeToA = await sink.write(fileA);
+    await pipe(writeFromA, writeToA);
+
+    const writeFromB = readFileStream('../../fixtures/import-map.json');
+    const writeToB = await sink.write(fileB);
+    await pipe(writeFromB, writeToB);
+
+    await sink.delete(fileA);
+
+    t.rejects(sink.exist(fileA), 'should reject on file A - file was deleted');
+    t.resolves(sink.exist(fileB), 'should resolve on file B - file was NOT deleted');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .delete() - Delete files recursively', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const fileA = `${dir}/a/map.json`;
+    const fileB = `${dir}/b/map.json`;
+
+    const writeFromA = readFileStream('../../fixtures/import-map.json');
+    const writeToA = await sink.write(fileA);
+    await pipe(writeFromA, writeToA);
+
+    const writeFromB = readFileStream('../../fixtures/import-map.json');
+    const writeToB = await sink.write(fileB);
+    await pipe(writeFromB, writeToB);
+
+    await sink.delete(dir);
+
+    t.rejects(sink.exist(fileA), 'should reject on file A - file was deleted');
+    t.rejects(sink.exist(fileB), 'should reject on file B - file was deleted');
+
+    t.end();
+});
+
+test('Sink() - .delete() - directory traversal prevention', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/map.json`;
+
+    t.rejects(sink.delete(`../../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../../ at beginning of filepath');
+    t.rejects(sink.delete(`../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../ at beginning of filepath');
+    t.rejects(sink.delete(`/${dir}/../../../foo/sensitive.data`), new Error('Directory traversal'), 'should reject on path traversal in the middle of filepath');
+    t.resolves(sink.delete(`./${file}`), 'should resolve on ./ at beginning of filepath');
+    t.resolves(sink.delete(`/${file}`), 'should resolve on / at beginning of filepath');
+    t.resolves(sink.delete(`//${file}`), 'should resolve on // at beginning of filepath');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .exist() - Check existing file', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/map.json`;
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    t.resolves(sink.exist(file), 'should resolve - file is in sink');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+
+test('Sink() - .exist() - Check non existing file', (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    t.rejects(sink.exist('/bar/foo/not-exist.json'), 'should reject - file does not exist');
+    t.end();
+});
+
+test('Sink() - .exist() - directory traversal prevention', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG);
+    const dir = slug();
+    const file = `${dir}/map.json`;
+
+    const writeFrom = readFileStream('../../fixtures/import-map.json');
+    const writeTo = await sink.write(file);
+
+    await pipe(writeFrom, writeTo);
+
+    t.rejects(sink.exist(`../../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../../ at beginning of filepath');
+    t.rejects(sink.exist(`../${dir}/sensitive.data`), new Error('Directory traversal'), 'should reject on ../ at beginning of filepath');
+    t.rejects(sink.exist(`/${dir}/../../../foo/sensitive.data`), new Error('Directory traversal'), 'should reject on path traversal in the middle of filepath');
+    t.resolves(sink.exist(`./${file}`), 'should resolve on ./ at beginning of filepath');
+    t.resolves(sink.exist(`/${file}`), 'should resolve on / at beginning of filepath');
+    t.resolves(sink.exist(`//${file}`), 'should resolve on // at beginning of filepath');
+
+    // Clean up sink
+    await sink.delete(dir);
+    t.end();
+});
+


### PR DESCRIPTION
When serving files we need to detect the mime type of each file so it can be set on the request headers. 

When running on a memory of `fs` sink, this needs to be parsed out of the request, but if running on a cloud storage bucket we can get this information from the buckets. We should do mime type parsing part of the sinks instead of the incoming http request. This PR appends mime type handling as part of the sink.