### PR TITLE
Avoid hitting max listeners exceeded warning

### DIFF
--- a/services/fastify.js
+++ b/services/fastify.js
@@ -69,6 +69,17 @@ class FastifyService {
 
         const mergeStreams = (...streams) => {
             const str = new PassThrough({ objectMode: true });
+
+            // Avoid hitting the max listeners limit when multiple
+            // streams is piped into the same stream.
+            str.on('pipe', () => {
+                str.setMaxListeners(str.getMaxListeners() + 1);
+            });
+
+            str.on('unpipe', () => {
+                str.setMaxListeners(str.getMaxListeners() - 1);
+            });
+
             for (const stm of streams) {
                 stm.on('error', err => {
                     this.log.error(err);


### PR DESCRIPTION
Avoids getting these warning messages on start:

```sh
(node:13679) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
```