### PR TITLE
Remove metric collector and specific logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,17 +20,12 @@
   "dependencies": {
     "@eik/common": "1.0.0-alpha.4",
     "@metrics/client": "2.5.0",
-    "@metrics/guard": "1.0.1",
-    "@metrics/prometheus-consumer": "3.0.1",
     "abslog": "2.4.0",
     "busboy": "0.3.1",
     "fastify": "2.13.0",
     "fastify-cors": "3.0.3",
     "http-errors": "1.7.3",
     "mime": "2.4.4",
-    "pino": "6.0.0",
-    "pino-pretty": "4.0.0",
-    "prom-client": "12.0.0",
     "rimraf": "3.0.2",
     "semver": "7.1.3",
     "tar": "6.0.1"


### PR DESCRIPTION
This removed the metric collector which was previously added and exposes a `.metrics` property with a metric stream instead. Collecting the metrics belong in the server code consuming this module.

This does also remove `pino` as logger and uses only `abslog` for the same above reason.