### PR TITLE
Use @eik/sink module

### DIFF
--- a/lib/sinks/fs.js
+++ b/lib/sinks/fs.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { ReadFile, Sink } = require('@eik/common');
+const { ReadFile } = require('@eik/common');
 const rimraf = require('rimraf');
+const Sink = require('@eik/sink');
 const mime = require('mime/lite');
 const path = require('path');
 const fs = require('fs');

--- a/lib/sinks/mem.js
+++ b/lib/sinks/mem.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const { Writable, Readable } = require('stream');
-const { ReadFile, Sink } = require('@eik/common');
+const { ReadFile } = require('@eik/common');
 const { join } = require('path');
+const Sink = require('@eik/sink');
 
 const Entry = require('./mem-entry');
 

--- a/lib/sinks/test.js
+++ b/lib/sinks/test.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { Writable, Readable } = require('stream');
-const { ReadFile, Sink } = require('@eik/common');
+const { ReadFile } = require('@eik/common');
+const Sink = require('@eik/sink');
 const mime = require('mime/lite');
 const path = require('path');
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@eik/common": "1.0.0-alpha.4",
     "@metrics/client": "2.5.0",
+    "@eik/common": "1.0.0-alpha.6",
+    "@eik/sink": "1.0.0",
     "abslog": "2.4.0",
     "busboy": "0.3.1",
     "fastify": "2.13.1",


### PR DESCRIPTION
This makes use of the new @eik/sink module instead of the sink which was in @eik/common.

