### PR TITLE
Support npm as package type

### DIFF
--- a/examples/npm.alias.delete.js
+++ b/examples/npm.alias.delete.js
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const FormData = require('form-data');
+const fetch = require('node-fetch');
+
+const authenticate = async (address) => {
+    const formData = new FormData();
+    formData.append('key', 'change_me');
+
+    const res = await fetch(`${address}/auth/login`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+
+    return res.json();
+}
+
+const del = async (address) => {
+    const auth = await authenticate(address);
+
+    const headers = {
+        'Authorization': `Bearer ${auth.token}`
+    };
+
+    const res = await fetch(`${address}/npm/fuzz/v8`, {
+        method: 'DELETE',
+        headers,
+    })
+
+    let result = {};
+    switch (res.status) {
+        case 204:
+            result = { status: res.status, message: 'Deleted' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    console.log(result);
+}
+
+del('http://localhost:4001');

--- a/examples/npm.alias.get.js
+++ b/examples/npm.alias.get.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const fetch = require('node-fetch');
+
+fetch('http://localhost:4001/npm/fuzz/v8/main/index.js', {
+    method: 'GET',
+})
+    .then(res => res.text())
+    .then(body => console.log(body));

--- a/examples/npm.alias.post.js
+++ b/examples/npm.alias.post.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const FormData = require('form-data');
+const fetch = require('node-fetch');
+
+const authenticate = async (address) => {
+    const formData = new FormData();
+    formData.append('key', 'change_me');
+
+    const res = await fetch(`${address}/auth/login`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+
+    return res.json();
+}
+
+const post = async (address) => {
+    const auth = await authenticate(address);
+
+    const formData = new FormData();
+    formData.append('version', '8.8.9');
+
+    const headers = {'Authorization': `Bearer ${auth.token}`, ...formData.getHeaders()};
+
+    const res = await fetch(`${address}/npm/fuzz/v8`, {
+        method: 'POST',
+        body: formData,
+        headers,
+    })
+
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = await res.json();
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    console.log(result);
+}
+
+post('http://localhost:4001');

--- a/examples/npm.alias.put.js
+++ b/examples/npm.alias.put.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const FormData = require('form-data');
+const fetch = require('node-fetch');
+
+const authenticate = async (address) => {
+    const formData = new FormData();
+    formData.append('key', 'change_me');
+
+    const res = await fetch(`${address}/auth/login`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+
+    return res.json();
+}
+
+const put = async (address) => {
+    const auth = await authenticate(address);
+
+    const formData = new FormData();
+    formData.append('version', '8.4.1');
+
+    const headers = {'Authorization': `Bearer ${auth.token}`, ...formData.getHeaders()};
+
+    const res = await fetch(`${address}/npm/fuzz/v8`, {
+        method: 'PUT',
+        body: formData,
+        headers,
+    })
+
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = await res.json();
+            break;
+        case 400:
+            result = { status: res.status, message: 'Invalid URL parameter' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 409:
+            result = { status: res.status, message: 'Alias exist' };
+            break;
+        case 415:
+            result = { status: res.status, message: 'Unsupported file format' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    console.log(result);
+}
+
+put('http://localhost:4001');

--- a/examples/npm.get.js
+++ b/examples/npm.get.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const fetch = require('node-fetch');
+
+fetch('http://localhost:4001/npm/fuzz/8.4.1/main/index.js', {
+    method: 'GET',
+})
+.then(res => res.text())
+.then(body => console.log(body));
+
+fetch('http://localhost:4001/npm/@cuz/fuzz/8.4.1/main/index.js', {
+    method: 'GET',
+})
+.then(res => res.text())
+.then(body => console.log(body));

--- a/examples/npm.put.js
+++ b/examples/npm.put.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const FormData = require('form-data');
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+const authenticate = async (address) => {
+    const formData = new FormData();
+    formData.append('key', 'change_me');
+
+    const res = await fetch(`${address}/auth/login`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+
+    return res.json();
+}
+
+const put = async (address) => {
+    const auth = await authenticate(address);
+
+    const formData = new FormData();
+    formData.append('package', fs.createReadStream('../fixtures/archive.tgz'));
+
+    const headers = {'Authorization': `Bearer ${auth.token}`, ...formData.getHeaders()};
+
+    const res = await fetch(`${address}/npm/fuzz/8.4.1`, {
+        method: 'PUT',
+        body: formData,
+        headers,
+    });
+
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = await res.json();
+            break;
+        case 400:
+            result = { status: res.status, message: 'Invalid URL parameter' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 409:
+            result = { status: res.status, message: 'Package exist' };
+            break;
+        case 415:
+            result = { status: res.status, message: 'Unsupported file format' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    console.log(result);
+}
+
+put('http://localhost:4001');

--- a/lib/classes/package.js
+++ b/lib/classes/package.js
@@ -5,11 +5,11 @@ const Asset = require('./asset');
 const Meta = require('./meta');
 
 const Package = class Package {
-    constructor({ version = '', name = '', org = '', author = {} } = {}) {
+    constructor({ version = '', type = '', name = '', org = '', author = {} } = {}) {
         this._version = version;
         this._created = Math.floor(new Date() / 1000);
         this._author = author;
-        this._type = 'package';
+        this._type = type;
         this._name = name;
         this._org = org;
         this._files = [];

--- a/lib/classes/versions.js
+++ b/lib/classes/versions.js
@@ -3,8 +3,9 @@
 const semver = require('semver');
 
 const Versions = class Versions {
-    constructor({ versions = [], name = '', org = '' } = {}) {
+    constructor({ versions = [], type = '', name = '', org = '' } = {}) {
         this._versions = new Map(versions);
+        this._type = type;
         this._name = name;
         this._org = org;
     }
@@ -13,6 +14,10 @@ const Versions = class Versions {
         return Array.from(this._versions.entries()).sort((a, b) => {
             return a[0] > b[0] ? -1 : 1;
         });
+    }
+
+    get type() {
+        return this._type;
     }
 
     get name() {
@@ -52,6 +57,7 @@ const Versions = class Versions {
     toJSON() {
         return {
             versions: this.versions,
+            type: this.type,
             name: this.name,
             org: this.org,
         };

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -39,7 +39,7 @@ const PkgGet = class PkgGet {
         return this._metrics;
     }
 
-    async handler(req, name, version, extra) {
+    async handler(req, type, name, version, extra) {
         const end = this._histogram.timer();
 
         const url = originalUrl(req);
@@ -56,6 +56,7 @@ const PkgGet = class PkgGet {
             validators.version(version);
             validators.extra(extra);
             validators.name(name);
+            validators.type(type);
         } catch (error) {
             this._log.debug(`pkg:get - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
@@ -67,6 +68,7 @@ const PkgGet = class PkgGet {
             pathname: extra,
             version,
             name,
+            type,
             org,
         });
 

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -37,7 +37,7 @@ const PkgLog = class PkgLog {
         return this._metrics;
     }
 
-    async handler(req, name, version) {
+    async handler(req, type, name, version) {
         const end = this._histogram.timer();
 
         const url = originalUrl(req);
@@ -53,6 +53,7 @@ const PkgLog = class PkgLog {
         try {
             validators.version(version);
             validators.name(name);
+            validators.type(type);
         } catch (error) {
             this._log.debug(`pkg:log - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
@@ -60,7 +61,7 @@ const PkgLog = class PkgLog {
             throw e;
         }
 
-        const path = createFilePathToPackage({ org, name, version });
+        const path = createFilePathToPackage({ org, type, name, version });
 
         try {
             const file = await this._sink.read(path);

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -195,7 +195,7 @@ const PkgPut = class PkgPut {
                 pathname: entry.path,
                 version: incoming.version,
                 name: incoming.name,
-                type: entry.type,
+                type: incoming.type,
                 org: incoming.org,
             });
             asset.size = entry.size;
@@ -264,7 +264,7 @@ const PkgPut = class PkgPut {
         );
     }
 
-    async handler(req, user, name, version) {
+    async handler(req, user, type, name, version) {
         const end = this._histogram.timer();
 
         const url = originalUrl(req);
@@ -280,6 +280,7 @@ const PkgPut = class PkgPut {
         try {
             validators.version(version);
             validators.name(name);
+            validators.type(type);
         } catch (error) {
             this._log.info(`pkg:put - Validation failed - ${error.message}`);
             const e = new HttpError.BadRequest();
@@ -292,7 +293,7 @@ const PkgPut = class PkgPut {
         const incoming = new HttpIncoming(req, {
             version,
             author,
-            type: 'pkg',
+            type,
             name,
             org,
         });
@@ -301,7 +302,7 @@ const PkgPut = class PkgPut {
 
         if (!versions.check(version)) {
             this._log.info(
-                `pkg:put - Semver version is lower than previous version of the package - Org: ${org} - Name: ${name} - Version: ${version}`,
+                `pkg:put - Semver version is lower than previous version of the package - Org: ${org} - Type: ${type} - Name: ${name} - Version: ${version}`,
             );
             const e = new HttpError.Conflict();
             end({ labels: { success: false, status: e.status } });

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,4 +40,5 @@ module.exports.prop = {
     base_auth: globals.BASE_AUTHENTICATION,
     base_map: globals.BASE_IMPORT_MAPS,
     base_pkg: globals.BASE_PACKAGES,
+    base_npm: globals.BASE_NPM,
 };

--- a/lib/utils/globals.js
+++ b/lib/utils/globals.js
@@ -4,6 +4,7 @@ const globals = {
     BASE_AUTHENTICATION: 'auth',
     BASE_IMPORT_MAPS: 'map',
     BASE_PACKAGES: 'pkg',
+    BASE_NPM: 'npm',
     ROOT: '/',
 };
 module.exports = globals;

--- a/lib/utils/path-builders-fs.js
+++ b/lib/utils/path-builders-fs.js
@@ -1,21 +1,21 @@
 'use strict';
 
 const path = require('path');
-const { BASE_IMPORT_MAPS, BASE_PACKAGES, ROOT } = require("./globals");
+const { BASE_IMPORT_MAPS, ROOT } = require("./globals");
 
 
 // Build file system path to a package file
 
-const createFilePathToPackage = ({ org = '', name = '', version = '' } = {}) => {
-    return path.join(ROOT, org, BASE_PACKAGES, name, `${version}.package.json`);
+const createFilePathToPackage = ({ org = '', type = '', name = '', version = '' } = {}) => {
+    return path.join(ROOT, org, type, name, `${version}.package.json`);
 }
 module.exports.createFilePathToPackage = createFilePathToPackage;
 
 
 // Build file system path to an asset in a package
 // pkgAsset
-const createFilePathToAsset = ({ org = '', name = '', version = '', asset = '' } = {}) => {
-    return path.join(ROOT, org, BASE_PACKAGES, name, version, asset);
+const createFilePathToAsset = ({ org = '', type = '', name = '', version = '', asset = '' } = {}) => {
+    return path.join(ROOT, org, type, name, version, asset);
 }
 module.exports.createFilePathToAsset = createFilePathToAsset;
 

--- a/lib/utils/path-builders-uri.js
+++ b/lib/utils/path-builders-uri.js
@@ -1,21 +1,21 @@
 'use strict';
 
 const path = require('path');
-const { BASE_IMPORT_MAPS, BASE_PACKAGES, ROOT } = require("./globals");
+const { BASE_IMPORT_MAPS, ROOT } = require("./globals");
 
 
 // Build URL pathname to a package log file
 
-const createURIPathToPkgLog = ({ name = '', version = '' } = {}) => {
-    return path.join(ROOT, BASE_PACKAGES, name, version);
+const createURIPathToPkgLog = ({ type = '', name = '', version = '' } = {}) => {
+    return path.join(ROOT, type, name, version);
 }
 module.exports.createURIPathToPkgLog = createURIPathToPkgLog;
 
 
 // Build URL pathname to an asset in a package
 
-const createURIPathToAsset = ({ name = '', version = '', asset = '' } = {}) => {
-    return path.join(ROOT, BASE_PACKAGES, name, version, asset);
+const createURIPathToAsset = ({ type = '', name = '', version = '', asset = '' } = {}) => {
+    return path.join(ROOT, type, name, version, asset);
 }
 module.exports.createURIPathToAsset = createURIPathToAsset;
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@metrics/client": "2.5.0",
-    "@eik/common": "1.0.0-alpha.6",
+    "@eik/common": "1.0.0-alpha.7",
     "@eik/sink": "1.0.0",
     "original-url": "1.2.3",
     "http-errors": "1.7.3",


### PR DESCRIPTION
This ads support for keeping npm as a package type. By introducing this, packages from npm is kept separate from "private" packages. This will avoid possible naming collisions.