### PR TITLE
Add sensible cache control defaults

### DIFF
--- a/lib/classes/http-outgoing.js
+++ b/lib/classes/http-outgoing.js
@@ -12,12 +12,23 @@ const STATUS_CODES = [
 
 const HttpOutgoing = class HttpOutgoing {
     constructor() {
+        this._cacheControl = 'no-store';
         this._statusCode = 200;
         this._mimeType = 'text/plain';
         this._location = '';
         this._stream = undefined;
         this._body = undefined;
         this._etag = '';
+    }
+
+    set cacheControl(value) {
+        if (value) {
+            this._cacheControl = value;
+        }
+    }
+
+    get cacheControl() {
+        return this._cacheControl;
     }
 
     set statusCode(value) {

--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -13,10 +13,12 @@ const config = require('../utils/defaults');
 const AliasDel = class AliasDel {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -99,6 +101,7 @@ const AliasDel = class AliasDel {
         );
 
         const outgoing = new HttpOutgoing();
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 204;
 
         end({ labels: { status: outgoing.statusCode } });

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -15,10 +15,12 @@ const config = require('../utils/defaults');
 const AliasGet = class AliasGet {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl || 'public, max-age=1200';
         this._sink = sink;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -69,8 +71,8 @@ const AliasGet = class AliasGet {
             const location = createURIToTargetOfAlias({ extra, ...obj });
 
             const outgoing = new HttpOutgoing();
-            outgoing.mimeType = 'application/json';
-            outgoing.statusCode = 303;
+            outgoing.cacheControl = this._cacheControl;
+            outgoing.statusCode = 307;
             outgoing.location = location;
 
             this._log.debug(`alias:get - Alias found - Pathname: ${path}`);

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -19,10 +19,12 @@ const config = require('../utils/defaults');
 const AliasPost = class AliasPost {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -181,7 +183,7 @@ const AliasPost = class AliasPost {
         await this._parser(incoming);
 
         const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'text/plain';
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 303;
         outgoing.location = createURIToAlias(incoming);
 

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -19,10 +19,12 @@ const config = require('../utils/defaults');
 const AliasPut = class AliasPut {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -181,7 +183,7 @@ const AliasPut = class AliasPut {
         await this._parser(incoming);
 
         const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'text/plain';
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 303;
         outgoing.location = createURIToAlias(incoming);
 

--- a/lib/handlers/auth.post.js
+++ b/lib/handlers/auth.post.js
@@ -14,10 +14,12 @@ const config = require('../utils/defaults');
 const AuthPost = class AuthPost {
     constructor({
         organizations,
+        cacheControl,
         authKey,
         logger,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._authKey = authKey || config.authKey;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -116,8 +118,9 @@ const AuthPost = class AuthPost {
         const obj = await this._parser(incoming);
 
         const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'application/json';
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 200;
+        outgoing.mimeType = 'application/json';
         outgoing.body = obj;
 
         end({ labels: { status: outgoing.statusCode } });

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -13,11 +13,13 @@ const config = require('../utils/defaults');
 const MapGet = class MapGet {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
         etag,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl || 'public, max-age=31536000, immutable';
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
@@ -65,8 +67,8 @@ const MapGet = class MapGet {
 
         try {
             const file = await this._sink.read(path);
-
             const outgoing = new HttpOutgoing();
+            outgoing.cacheControl = this._cacheControl;
             outgoing.mimeType = 'application/json';
 
             if (this._etag) {

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -24,11 +24,13 @@ const MapPut = class MapPut {
     constructor({
         mapMaxFileSize,
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._mapMaxFileSize = mapMaxFileSize || config.mapMaxFileSize;
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
         this._log = abslog(logger);
@@ -212,7 +214,7 @@ const MapPut = class MapPut {
         }
 
         const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'text/plain';
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 303;
         outgoing.location = createURIPathToImportMap(incoming);
 

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -14,11 +14,13 @@ const config = require('../utils/defaults');
 const PkgGet = class PkgGet {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
         etag,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl || 'public, max-age=31536000, immutable';
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
@@ -77,6 +79,7 @@ const PkgGet = class PkgGet {
         try {
             const file = await this._sink.read(path);
             const outgoing = new HttpOutgoing();
+            outgoing.cacheControl = this._cacheControl;
             outgoing.mimeType = asset.mimeType;
 
             if (this._etag) {

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -13,11 +13,13 @@ const config = require('../utils/defaults');
 const PkgLog = class PkgLog {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
         etag,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl || 'no-cache';
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
@@ -66,6 +68,7 @@ const PkgLog = class PkgLog {
         try {
             const file = await this._sink.read(path);
             const outgoing = new HttpOutgoing();
+            outgoing.cacheControl = this._cacheControl;
             outgoing.mimeType = 'application/json';
 
             if (this._etag) {

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -30,11 +30,13 @@ const PkgPut = class PkgPut {
     constructor({
         pkgMaxFileSize,
         organizations,
+        cacheControl,
         logger,
         sink,
     } = {}) {
         this._pkgMaxFileSize = pkgMaxFileSize || config.pkgMaxFileSize;
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
         this._metrics = new Metrics();
@@ -321,7 +323,7 @@ const PkgPut = class PkgPut {
         }
 
         const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'text/plain';
+        outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 303;
         outgoing.location = createURIPathToPkgLog(pkg);
 

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -13,11 +13,13 @@ const config = require('../utils/defaults');
 const VersionsGet = class VersionsGet {
     constructor({
         organizations,
+        cacheControl,
         logger,
         sink,
         etag,
     } = {}) {
         this._organizations = organizations || config.organizations;
+        this._cacheControl = cacheControl || 'no-cache';
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
@@ -68,6 +70,7 @@ const VersionsGet = class VersionsGet {
         try {
             const file = await this._sink.read(path);
             const outgoing = new HttpOutgoing();
+            outgoing.cacheControl = this._cacheControl;
             outgoing.mimeType = 'application/json';
 
             if (this._etag) {


### PR DESCRIPTION
This appends sensible http cache control headers to all routes.

 * All `PUT`, `POST` and `DELETE` routes is set to not be cached or stored. 
 * The packages and map `GET` routes is set to be forever cached. 
 * The packages log and version `GET` routes is set to be not cached but re-validated.
 * The packages and map alias `GET` redirects is set to be cached for 20 minutes.

This also changes the http status code on packages and map alias `GET` redirects from a `303` to a `307` which is more correct.