### PR TITLE
Add health check for checking the sink

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,10 @@ const MapPut = require('./handlers/map.put');
 const MEM = require('./sinks/mem');
 const FS = require('./sinks/fs');
 
+const HealthCheck = require('./utils/healthcheck');
 const globals = require('./utils/globals');
+
+module.exports.HealthCheck = HealthCheck;
 
 module.exports.http = {
     VersionsGet,

--- a/lib/utils/healthcheck.js
+++ b/lib/utils/healthcheck.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { Writable, pipeline } = require('stream');
+const abslog = require('abslog');
+const slug = require('unique-slug');
+const path = require('path');
+const fs = require('fs');
+
+const fileReader = (file = '../../README.md') => {
+    const pathname = path.join(__dirname, file);
+    return fs.createReadStream(pathname);
+};
+
+const HealthCheck = class HealthCheck {
+    constructor({ sink, logger } = {}) {
+        this._sink = sink;
+        this._name = `./system/tmp/health_${slug()}.txt`;
+        this._log = abslog(logger);
+    }
+
+    _write() {
+        return new Promise((resolve, reject) => {
+            this._sink.write(this._name, 'text/plain').then((destination) => {
+                const source = fileReader();
+                pipeline(source, destination, (error) => {
+                    if (error) return reject(error);
+                    return resolve();
+                });
+            }).catch((error) => {
+                reject(error);
+            });
+        });
+    }
+
+    _read() {
+        return new Promise(async (resolve, reject) => {
+            this._sink.read(this._name).then((source) => {
+                const buffer = [];
+                const destination = new Writable({
+                    objectMode: false,
+                    write(chunk, encoding, callback) {
+                        buffer.push(chunk);
+                        callback();
+                    },
+                });
+
+                pipeline(source.stream, destination, (error) => {
+                    if (error) return reject(error);
+                    return resolve();
+                });
+            }).catch((error) => {
+                reject(error);
+            });
+        });
+    }
+
+    _delete() {
+        return this._sink.delete(this._name);
+    }
+
+    _exist() {
+        return this._sink.exist(this._name);
+    }
+
+    async check() {
+        this._log.info(`Sink health check started - testing with file ${this._name}`);
+
+        try {
+            await this._write();
+        } catch (error) {
+            this._log.warn('Sink health check errored during write');
+            this._log.error(error);
+            throw error;
+        }
+
+        try {
+            await this._exist();
+        } catch (error) {
+            this._log.warn('Sink health check errored when checking content written by sink.write(). Content was probably not written to sink.');
+            this._log.error(error);
+            throw error;
+        }
+
+        try {
+            await this._read();
+        } catch (error) {
+            this._log.warn('Sink health check errored during read');
+            this._log.error(error);
+            throw error;
+        }
+
+        try {
+            await this._delete();
+        } catch (error) {
+            this._log.warn('Sink health check errored during deletion');
+            this._log.error(error);
+            throw error;
+        }
+
+        try {
+            await this._exist();
+            this._log.warn('Sink health check successfully read file after deletion. It should not. Content was probably not deleted by sink.delete().');
+            throw new Error('File exist in sink');
+        } catch (error) {
+            this._log.info('Sink health check ended successfully. Sink is healthy');
+        }
+
+        return true;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'HealthCheck';
+    }
+}
+module.exports = HealthCheck;

--- a/lib/utils/healthcheck.js
+++ b/lib/utils/healthcheck.js
@@ -33,7 +33,7 @@ const HealthCheck = class HealthCheck {
     }
 
     _read() {
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             this._sink.read(this._name).then((source) => {
                 const buffer = [];
                 const destination = new Writable({

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "rimraf": "3.0.2",
     "semver": "7.3.2",
     "ssri": "8.0.0",
-    "tar": "6.0.2"
+    "tar": "6.0.2",
+    "unique-slug": "2.0.2"
   },
   "devDependencies": {
     "eslint": "7.1.0",
@@ -40,7 +41,6 @@
     "mkdirp": "1.0.3",
     "node-fetch": "2.6.0",
     "prettier": "2.0.2",
-    "tap": "14.10.7",
-    "unique-slug": "2.0.2"
+    "tap": "14.10.7"
   }
 }

--- a/test/utils/healthchecks.js
+++ b/test/utils/healthchecks.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const tap = require('tap');
+
+const HealthCheck = require('../../lib/utils/healthcheck');
+const Sink = require('../../lib/sinks/test');
+
+tap.test('HealthCheck() - Object type', (t) => {
+    const health = new HealthCheck();
+    const name = Object.prototype.toString.call(health);
+    t.true(name.startsWith('[object HealthCheck'), 'should begin with HealthCheck');
+    t.end();
+});
+
+tap.test('HealthCheck() - Sink is healthy', (t) => {
+    const sink = new Sink();
+
+    const health = new HealthCheck({ sink });
+    const check = health.check();
+
+    t.resolveMatch(check, true, 'Should resolve with "true" as a value');
+    t.end();
+});


### PR DESCRIPTION
This ads a sink health check. It does all the operations the service need to do to operate on files in a storage to work properly. If all checks pass it will report success. If any steps fails it will report which step failed.