### PR TITLE
fix: Add buckets to histograms

### DIFF
--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -29,6 +29,16 @@ const AliasDel = class AliasDel {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -31,6 +31,16 @@ const AliasGet = class AliasGet {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -35,6 +35,16 @@ const AliasPost = class AliasPost {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
 

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -35,6 +35,16 @@ const AliasPut = class AliasPut {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
 

--- a/lib/handlers/auth.post.js
+++ b/lib/handlers/auth.post.js
@@ -30,6 +30,16 @@ const AuthPost = class AuthPost {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
 

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -32,6 +32,16 @@ const MapGet = class MapGet {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -42,6 +42,16 @@ const MapPut = class MapPut {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -33,6 +33,16 @@ const PkgGet = class PkgGet {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -31,6 +31,16 @@ const PkgLog = class PkgLog {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -42,6 +42,16 @@ const PkgPut = class PkgPut {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
 

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -32,6 +32,16 @@ const VersionsGet = class VersionsGet {
             labels: {
                 success: true,
             },
+            buckets: [
+                0.005,
+                0.01,
+                0.06,
+                0.1,
+                0.6,
+                1.0,
+                2.0,
+                4.0,
+            ],
         });
         this._orgRegistry = new Map(this._organizations);
     }


### PR DESCRIPTION
This ads predefined buckets to histograms to reduce the amount of permutations in the metrics.