### PR TITLE
fix: Add type as label to histograms

### DIFF
--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -28,6 +28,7 @@ const AliasDel = class AliasDel {
                 'Histogram measuring time taken in @eik/core AliasDel handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -76,7 +77,7 @@ const AliasDel = class AliasDel {
         if (!org) {
             this._log.info(`alias:del - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -87,7 +88,7 @@ const AliasDel = class AliasDel {
                 `alias:del - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
             );
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -102,7 +103,7 @@ const AliasDel = class AliasDel {
             );
             this._log.trace(error);
             const e = new HttpError.BadGateway();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             return e;
         }
 
@@ -114,7 +115,7 @@ const AliasDel = class AliasDel {
         outgoing.cacheControl = this._cacheControl;
         outgoing.statusCode = 204;
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type } });
 
         return outgoing;
     }

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -30,6 +30,7 @@ const AliasGet = class AliasGet {
                 'Histogram measuring time taken in @eik/core AliasGet handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -60,7 +61,7 @@ const AliasGet = class AliasGet {
         } catch (error) {
             this._log.debug(`alias:get - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: 404 } });
+            end({ labels: { success: false, status: e.status } });
             throw e;
         }
 
@@ -70,7 +71,7 @@ const AliasGet = class AliasGet {
         if (!org) {
             this._log.info(`alias:get - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -87,13 +88,13 @@ const AliasGet = class AliasGet {
 
             this._log.debug(`alias:get - Alias found - Pathname: ${path}`);
 
-            end({ labels: { status: outgoing.statusCode } });
+            end({ labels: { status: outgoing.statusCode, type } });
 
             return outgoing;
         } catch (error) {
             this._log.debug(`alias:get - Alias not found - Pathname: ${path}`);
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
     }

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -34,6 +34,7 @@ const AliasPost = class AliasPost {
                 'Histogram measuring time taken in @eik/core AliasPost handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -136,7 +137,7 @@ const AliasPost = class AliasPost {
         if (!org) {
             this._log.info(`alias:post - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -156,7 +157,7 @@ const AliasPost = class AliasPost {
                 `alias:post - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
             );
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -167,7 +168,7 @@ const AliasPost = class AliasPost {
         outgoing.statusCode = 303;
         outgoing.location = createURIToAlias(incoming);
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type } });
 
         return outgoing;
     }

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -34,6 +34,7 @@ const AliasPut = class AliasPut {
                 'Histogram measuring time taken in @eik/core AliasPut handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -135,7 +136,7 @@ const AliasPut = class AliasPut {
         if (!org) {
             this._log.info(`alias:put - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -155,7 +156,7 @@ const AliasPut = class AliasPut {
                 `alias:put - Alias exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
             );
             const e = new HttpError.Conflict();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -166,7 +167,7 @@ const AliasPut = class AliasPut {
         outgoing.statusCode = 303;
         outgoing.location = createURIToAlias(incoming);
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type } });
 
         return outgoing;
     }

--- a/lib/handlers/auth.post.js
+++ b/lib/handlers/auth.post.js
@@ -29,6 +29,7 @@ const AuthPost = class AuthPost {
                 'Histogram measuring time taken in @eik/core AuthPost handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -86,7 +87,7 @@ const AuthPost = class AuthPost {
         if (!org) {
             this._log.info(`auth:post - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'auth' } });
             throw e;
         }
 
@@ -102,7 +103,7 @@ const AuthPost = class AuthPost {
         outgoing.mimeType = 'application/json';
         outgoing.body = obj;
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type: 'auth' } });
 
         return outgoing;
     }

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -31,6 +31,7 @@ const MapGet = class MapGet {
                 'Histogram measuring time taken in @eik/core MapGet handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -69,7 +70,7 @@ const MapGet = class MapGet {
         if (!org) {
             this._log.info(`map:get - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }
 
@@ -98,7 +99,7 @@ const MapGet = class MapGet {
 
             this._log.debug(`map:get - Import map found - Pathname: ${path}`);
 
-            end({ labels: { status: outgoing.statusCode } });
+            end({ labels: { status: outgoing.statusCode, type: 'map' } });
 
             return outgoing;
         } catch (error) {
@@ -106,7 +107,7 @@ const MapGet = class MapGet {
                 `map:get - Import map not found - Pathname: ${path}`,
             );
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }
     }

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -41,6 +41,7 @@ const MapPut = class MapPut {
                 'Histogram measuring time taken in @eik/core MapPut handler method',
             labels: {
                 success: true,
+                type: 'unknown'
             },
             buckets: [
                 0.005,
@@ -187,7 +188,7 @@ const MapPut = class MapPut {
         if (!org) {
             this._log.info(`map:put - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }
 
@@ -208,7 +209,7 @@ const MapPut = class MapPut {
                 `map:put - Semver version is lower than previous version of the package - Org: ${org} - Name: ${name} - Version: ${version}`,
             );
             const e = new HttpError.Conflict();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }
 
@@ -219,7 +220,7 @@ const MapPut = class MapPut {
             await this._writeVersions(incoming, versions);
         } catch (error) {
             const e = new HttpError.BadGateway();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }
 
@@ -228,7 +229,7 @@ const MapPut = class MapPut {
         outgoing.statusCode = 303;
         outgoing.location = createURIPathToImportMap(incoming);
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type: 'map' } });
 
         return outgoing;
     }

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -32,6 +32,7 @@ const PkgGet = class PkgGet {
                 'Histogram measuring time taken in @eik/core PkgGet handler method',
             labels: {
                 success: true,
+                type: 'unknown'
             },
             buckets: [
                 0.005,
@@ -72,7 +73,7 @@ const PkgGet = class PkgGet {
         if (!org) {
             this._log.info(`pkg:get - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -109,13 +110,13 @@ const PkgGet = class PkgGet {
 
             this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
 
-            end({ labels: { status: outgoing.statusCode } });
+            end({ labels: { status: outgoing.statusCode, type } });
 
             return outgoing;
         } catch (error) {
             this._log.debug(`pkg:get - Asset not found - Pathname: ${path}`);
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
     }

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -30,6 +30,7 @@ const PkgLog = class PkgLog {
                 'Histogram measuring time taken in @eik/core PkgLog handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -59,7 +60,7 @@ const PkgLog = class PkgLog {
         } catch (error) {
             this._log.debug(`pkg:log - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -69,7 +70,7 @@ const PkgLog = class PkgLog {
         if (!org) {
             this._log.info(`pkg:log - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -98,13 +99,13 @@ const PkgLog = class PkgLog {
 
             this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
 
-            end({ labels: { status: outgoing.statusCode } });
+            end({ labels: { status: outgoing.statusCode, type } });
 
             return outgoing;
         } catch (error) {
             this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
     }

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -41,6 +41,7 @@ const PkgPut = class PkgPut {
                 'Histogram measuring time taken in @eik/core PkgPut handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -148,7 +149,7 @@ const PkgPut = class PkgPut {
         if (!org) {
             this._log.info(`pkg:put - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -169,7 +170,7 @@ const PkgPut = class PkgPut {
                 `pkg:put - Semver version is lower than previous version of the package - Org: ${org} - Type: ${type} - Name: ${name} - Version: ${version}`,
             );
             const e = new HttpError.Conflict();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -180,7 +181,7 @@ const PkgPut = class PkgPut {
             await this._writeVersions(incoming, versions);
         } catch (error) {
             const e = new HttpError.BadGateway();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
@@ -189,7 +190,7 @@ const PkgPut = class PkgPut {
         outgoing.statusCode = 303;
         outgoing.location = createURIPathToPkgLog(pkg);
 
-        end({ labels: { status: outgoing.statusCode } });
+        end({ labels: { status: outgoing.statusCode, type } });
 
         return outgoing;
     }

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -31,6 +31,7 @@ const VersionsGet = class VersionsGet {
                 'Histogram measuring time taken in @eik/core VersionsGet handler method',
             labels: {
                 success: true,
+                type: 'unknown',
             },
             buckets: [
                 0.005,
@@ -71,7 +72,7 @@ const VersionsGet = class VersionsGet {
         if (!org) {
             this._log.info(`pkg:latest - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
         const path = createFilePathToVersion({ org, type, name });
@@ -101,7 +102,7 @@ const VersionsGet = class VersionsGet {
                 `pkg:latest - Package log found - Pathname: ${path}`,
             );
 
-            end({ labels: { status: outgoing.statusCode } });
+            end({ labels: { status: outgoing.statusCode, type } });
 
             return outgoing;
         } catch (error) {
@@ -109,7 +110,7 @@ const VersionsGet = class VersionsGet {
                 `pkg:latest - Package log found - Pathname: ${path}`,
             );
             const e = new HttpError.NotFound();
-            end({ labels: { success: false, status: e.status } });
+            end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
     }


### PR DESCRIPTION
The request handlers can be used between http routes. Ex, the same handlers are used to handle both eik packages and npm packages, the only thing separating them is a `type` which can be `pkg` or `npm` in the URLs and on the file system.

This adds a `type` label on the metrics to all handlers which reflects the `type` value used to separate this in the URLs and on the file system making it possible to differentiate on this in the metrics.