### PR TITLE
feat: Decode URL encoded URL parameters

### DIFF
--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -9,6 +9,7 @@ const abslog = require('abslog');
 const { createFilePathToAlias } = require('../utils/path-builders-fs');
 const HttpOutgoing = require('../classes/http-outgoing');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const AliasDel = class AliasDel {
     constructor({
@@ -60,9 +61,12 @@ const AliasDel = class AliasDel {
     async handler(req, user, type, name, alias) {
         const end = this._histogram.timer();
 
+        const pAlias = utils.decodeUriComponent(alias);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.alias(alias);
-            validators.name(name);
+            validators.alias(pAlias);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.info(`alias:del - Validation failed - ${error.message}`);
@@ -81,11 +85,11 @@ const AliasDel = class AliasDel {
             throw e;
         }
 
-        const path = createFilePathToAlias({ org, type, name, alias });
+        const path = createFilePathToAlias({ org, type, name: pName, alias: pAlias });
         const exist = await this._exist(path);
         if (!exist) {
             this._log.info(
-                `alias:del - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
+                `alias:del - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${pName} - Alias: ${pAlias}`,
             );
             const e = new HttpError.NotFound();
             end({ labels: { success: false, status: e.status, type } });

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -53,10 +53,14 @@ const AliasGet = class AliasGet {
     async handler(req, type, name, alias, extra) {
         const end = this._histogram.timer();
 
+        const pAlias = utils.decodeUriComponent(alias);
+        const pExtra = utils.decodeUriComponent(extra);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.alias(alias);
-            validators.extra(extra);
-            validators.name(name);
+            validators.alias(pAlias);
+            validators.extra(pExtra);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.debug(`alias:get - Validation failed - ${error.message}`);
@@ -75,11 +79,11 @@ const AliasGet = class AliasGet {
             throw e;
         }
 
-        const path = createFilePathToAlias({ org, type, name, alias });
+        const path = createFilePathToAlias({ org, type, name: pName, alias: pAlias });
 
         try {
             const obj = await utils.readJSON(this._sink, path);
-            const location = createURIToTargetOfAlias({ extra, ...obj });
+            const location = createURIToTargetOfAlias({ extra: pExtra, ...obj });
 
             const outgoing = new HttpOutgoing();
             outgoing.cacheControl = this._cacheControl;

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -13,8 +13,8 @@ const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Author = require('../classes/author');
 const Alias = require('../classes/alias');
-const utils = require('../utils/utils');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const AliasPost = class AliasPost {
     constructor({
@@ -120,9 +120,12 @@ const AliasPost = class AliasPost {
     async handler(req, user, type, name, alias) {
         const end = this._histogram.timer();
 
+        const pAlias = utils.decodeUriComponent(alias);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.alias(alias);
-            validators.name(name);
+            validators.alias(pAlias);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.info(`alias:post - Validation failed - ${error.message}`);
@@ -145,8 +148,8 @@ const AliasPost = class AliasPost {
 
         const incoming = new HttpIncoming(req, {
             author,
-            alias,
-            name,
+            alias: pAlias,
+            name: pName,
             type,
             org,
         });
@@ -154,7 +157,7 @@ const AliasPost = class AliasPost {
         const exist = await this._exist(incoming);
         if (!exist) {
             this._log.info(
-                `alias:post - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
+                `alias:post - Alias does not exists - Org: ${org} - Type: ${type} - Name: ${pName} - Alias: ${pAlias}`,
             );
             const e = new HttpError.NotFound();
             end({ labels: { success: false, status: e.status, type } });

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -119,9 +119,12 @@ const AliasPut = class AliasPut {
     async handler(req, user, type, name, alias) {
         const end = this._histogram.timer();
 
+        const pAlias = utils.decodeUriComponent(alias);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.alias(alias);
-            validators.name(name);
+            validators.alias(pAlias);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.info(`alias:put - Validation failed - ${error.message}`);
@@ -144,8 +147,8 @@ const AliasPut = class AliasPut {
 
         const incoming = new HttpIncoming(req, {
             author,
-            alias,
-            name,
+            alias: pAlias,
+            name: pName,
             type,
             org,
         });
@@ -153,7 +156,7 @@ const AliasPut = class AliasPut {
         const exist = await this._exist(incoming);
         if (exist) {
             this._log.info(
-                `alias:put - Alias exists - Org: ${org} - Type: ${type} - Name: ${name} - Alias: ${alias}`,
+                `alias:put - Alias exists - Org: ${org} - Type: ${type} - Name: ${pName} - Alias: ${pAlias}`,
             );
             const e = new HttpError.Conflict();
             end({ labels: { success: false, status: e.status, type } });

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -9,6 +9,7 @@ const Metrics = require('@metrics/client');
 const { createFilePathToImportMap } = require('../utils/path-builders-fs');
 const HttpOutgoing = require('../classes/http-outgoing');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const MapGet = class MapGet {
     constructor({
@@ -54,9 +55,12 @@ const MapGet = class MapGet {
     async handler(req, name, version) {
         const end = this._histogram.timer();
 
+        const pVersion = utils.decodeUriComponent(version);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.version(version);
-            validators.name(name);
+            validators.version(pVersion);
+            validators.name(pName);
         } catch (error) {
             this._log.debug(`map:get - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
@@ -74,7 +78,7 @@ const MapGet = class MapGet {
             throw e;
         }
 
-        const path = createFilePathToImportMap({ org, name, version });
+        const path = createFilePathToImportMap({ org, name: pName, version: pVersion });
 
         try {
             const file = await this._sink.read(path);

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -17,8 +17,8 @@ const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Versions = require('../classes/versions');
 const Author = require('../classes/author');
-const utils = require('../utils/utils');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const MapPut = class MapPut {
     constructor({
@@ -172,9 +172,12 @@ const MapPut = class MapPut {
     async handler(req, user, name, version) {
         const end = this._histogram.timer();
 
+        const pVersion = utils.decodeUriComponent(version);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.version(version);
-            validators.name(name);
+            validators.version(pVersion);
+            validators.name(pName);
         } catch (error) {
             this._log.info(`map:put - Validation failed - ${error.message}`);
             const e = new HttpError.BadRequest();
@@ -196,17 +199,17 @@ const MapPut = class MapPut {
 
         const incoming = new HttpIncoming(req, {
             type: 'map',
-            version,
+            version: pVersion,
             author,
-            name,
+            name: pName,
             org,
         });
 
         const versions = await this._readVersions(incoming);
 
-        if (!versions.check(version)) {
+        if (!versions.check(pVersion)) {
             this._log.info(
-                `map:put - Semver version is lower than previous version of the package - Org: ${org} - Name: ${name} - Version: ${version}`,
+                `map:put - Semver version is lower than previous version of the package - Org: ${org} - Name: ${pName} - Version: ${pVersion}`,
             );
             const e = new HttpError.Conflict();
             end({ labels: { success: false, status: e.status, type: 'map' } });
@@ -214,7 +217,7 @@ const MapPut = class MapPut {
         }
 
         const integrity = await this._parser(incoming);
-        versions.setVersion(version, integrity);
+        versions.setVersion(pVersion, integrity);
 
         try {
             await this._writeVersions(incoming, versions);

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -10,6 +10,7 @@ const { createFilePathToAsset } = require('../utils/path-builders-fs');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Asset = require('../classes/asset');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const PkgGet = class PkgGet {
     constructor({
@@ -55,10 +56,14 @@ const PkgGet = class PkgGet {
     async handler(req, type, name, version, extra) {
         const end = this._histogram.timer();
 
+        const pVersion = utils.decodeUriComponent(version);
+        const pExtra = utils.decodeUriComponent(extra);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.version(version);
-            validators.extra(extra);
-            validators.name(name);
+            validators.version(pVersion);
+            validators.extra(pExtra);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.debug(`pkg:get - Validation failed - ${error.message}`);
@@ -78,9 +83,9 @@ const PkgGet = class PkgGet {
         }
 
         const asset = new Asset({
-            pathname: extra,
-            version,
-            name,
+            pathname: pExtra,
+            version: pVersion,
+            name: pName,
             type,
             org,
         });

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -9,6 +9,7 @@ const Metrics = require('@metrics/client');
 const { createFilePathToPackage } = require('../utils/path-builders-fs');
 const HttpOutgoing = require('../classes/http-outgoing');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const PkgLog = class PkgLog {
     constructor({
@@ -53,9 +54,12 @@ const PkgLog = class PkgLog {
     async handler(req, type, name, version) {
         const end = this._histogram.timer();
 
+        const pVersion = utils.decodeUriComponent(version);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.version(version);
-            validators.name(name);
+            validators.version(pVersion);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.debug(`pkg:log - Validation failed - ${error.message}`);
@@ -74,7 +78,7 @@ const PkgLog = class PkgLog {
             throw e;
         }
 
-        const path = createFilePathToPackage({ org, type, name, version });
+        const path = createFilePathToPackage({ org, type, name: pName, version: pVersion });
 
         try {
             const file = await this._sink.read(path);

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -132,9 +132,12 @@ const PkgPut = class PkgPut {
     async handler(req, user, type, name, version) {
         const end = this._histogram.timer();
 
+        const pVersion = utils.decodeUriComponent(version);
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.version(version);
-            validators.name(name);
+            validators.version(pVersion);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.info(`pkg:put - Validation failed - ${error.message}`);
@@ -156,18 +159,18 @@ const PkgPut = class PkgPut {
         const author = new Author(user);
 
         const incoming = new HttpIncoming(req, {
-            version,
+            version: pVersion,
             author,
             type,
-            name,
+            name: pName,
             org,
         });
 
         const versions = await this._readVersions(incoming);
 
-        if (!versions.check(version)) {
+        if (!versions.check(pVersion)) {
             this._log.info(
-                `pkg:put - Semver version is lower than previous version of the package - Org: ${org} - Type: ${type} - Name: ${name} - Version: ${version}`,
+                `pkg:put - Semver version is lower than previous version of the package - Org: ${org} - Type: ${type} - Name: ${pName} - Version: ${pVersion}`,
             );
             const e = new HttpError.Conflict();
             end({ labels: { success: false, status: e.status, type } });
@@ -175,7 +178,7 @@ const PkgPut = class PkgPut {
         }
 
         const pkg = await this._parser(incoming);
-        versions.setVersion(version, pkg.integrity);
+        versions.setVersion(pVersion, pkg.integrity);
 
         try {
             await this._writeVersions(incoming, versions);

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -9,6 +9,7 @@ const abslog = require('abslog');
 const { createFilePathToVersion } = require('../utils/path-builders-fs');
 const HttpOutgoing = require('../classes/http-outgoing');
 const config = require('../utils/defaults');
+const utils = require('../utils/utils');
 
 const VersionsGet = class VersionsGet {
     constructor({
@@ -54,8 +55,10 @@ const VersionsGet = class VersionsGet {
     async handler(req, type, name) {
         const end = this._histogram.timer();
 
+        const pName = utils.decodeUriComponent(name);
+
         try {
-            validators.name(name);
+            validators.name(pName);
             validators.type(type);
         } catch (error) {
             this._log.debug(
@@ -75,7 +78,7 @@ const VersionsGet = class VersionsGet {
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
-        const path = createFilePathToVersion({ org, type, name });
+        const path = createFilePathToVersion({ org, type, name: pName });
 
         try {
             const file = await this._sink.read(path);

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -83,3 +83,10 @@ const etagFromFsStat = (stat) => {
     return `W/"${size}-${mtime}"`;
 };
 module.exports.etagFromFsStat = etagFromFsStat;
+
+
+const decodeUriComponent = (value) => {
+    if (value === null || value === undefined) return value;
+    return decodeURIComponent(value);
+}
+module.exports.decodeUriComponent = decodeUriComponent;

--- a/test/handlers/alias.delete.js
+++ b/test/handlers/alias.delete.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { PassThrough } = require('stream');
+const FormData = require('form-data');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/alias.delete.js');
+const Sink = require('../../lib/sinks/test');
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+
+tap.test('alias.delete() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/pkg/@foo/foo-bar/8.alias.json', 'payload');
+
+    const h = new Handler({ sink });
+    
+    const formData = new FormData();
+    formData.append('version', '8.1.4-1');
+
+    const headers = formData.getHeaders();
+    const req = new Request({ headers });
+    formData.pipe(req);
+
+    const res = await h.handler(req, 'anton', 'pkg', '%40foo%2Ffoo-bar', '8');
+
+    t.equal(res.statusCode, 204, 'should respond with expected status code');
+    t.equal(sink.get('/pkg/@foo/foo-bar/8.alias.json'), null, 'should delete alias from sink');
+    t.end();
+});

--- a/test/handlers/alias.get.js
+++ b/test/handlers/alias.get.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { PassThrough } = require('stream');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/alias.get.js');
+const Alias = require('../../lib/classes/alias');
+const Sink = require('../../lib/sinks/test');
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('alias.get() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    const alias = new Alias({
+        alias: '8',
+        name: '@foo/bar-lib',
+        type: 'pkg',
+        org: 'localhost',
+    });
+    alias.version = '8.1.4-1';
+    sink.set('/local/pkg/@foo/bar-lib/8.alias.json', JSON.stringify(alias));
+    
+    const h = new Handler({ sink });
+    const req = new Request();
+    const res = await h.handler(req, 'pkg', '%40foo%2Fbar-lib', '8', '%2Ffoo%2Fmain.js');
+
+    t.equal(res.statusCode, 302, 'should respond with expected status code');
+    t.equal(res.location, '/pkg/@foo/bar-lib/8.1.4-1/foo/main.js', '.location should be decoded');
+    t.end();
+});

--- a/test/handlers/alias.post.js
+++ b/test/handlers/alias.post.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { PassThrough } = require('stream');
+const FormData = require('form-data');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/alias.post.js');
+const Sink = require('../../lib/sinks/test');
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+
+tap.test('alias.post() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/pkg/@foo/bar-lib/8.alias.json', 'payload');
+
+    const h = new Handler({ sink });
+
+    const formData = new FormData();
+    formData.append('version', '8.1.4-1');
+
+    const headers = formData.getHeaders();
+    const req = new Request({ headers });
+    formData.pipe(req);
+
+    const res = await h.handler(req, 'anton', 'pkg', '%40foo%2Fbar-lib', '8');
+
+    t.equal(res.statusCode, 303, 'should respond with expected status code');
+    t.equal(res.location, '/pkg/@foo/bar-lib/v8', '.location should be decoded');
+    t.end();
+});

--- a/test/handlers/alias.put.js
+++ b/test/handlers/alias.put.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { PassThrough } = require('stream');
+const FormData = require('form-data');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/alias.put.js');
+const Sink = require('../../lib/sinks/test');
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+
+tap.test('alias.put() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    const h = new Handler({ sink });
+
+    const formData = new FormData();
+    formData.append('version', '8.1.4-1');
+
+    const headers = formData.getHeaders();
+    const req = new Request({ headers });
+    formData.pipe(req);
+
+    const res = await h.handler(req, 'anton', 'pkg', '%40foo%2Fbar-lib', '8');
+
+    t.equal(res.statusCode, 303, 'should respond with expected status code');
+    t.equal(res.location, '/pkg/@foo/bar-lib/v8', '.location should be decoded');
+    t.end();
+});

--- a/test/handlers/map.get.js
+++ b/test/handlers/map.get.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { Writable, PassThrough, pipeline } = require('stream');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/map.get.js');
+const Sink = require('../../lib/sinks/test');
+
+const pipeInto = (...streams) => new Promise((resolve, reject) => {
+    const buffer = [];
+
+    const to = new Writable({
+        objectMode: false,
+        write(chunk, encoding, callback) {
+            buffer.push(chunk);
+            callback();
+        },
+    });
+
+    pipeline(...streams, to, error => {
+        if (error) return reject(error);
+        const str = buffer.join('').toString();
+        return resolve(str);
+    });
+})
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('pkg.get() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/map/@foo/bar-lib/8.1.4-1.import-map.json', 'payload');
+
+    const h = new Handler({ sink });
+    const req = new Request();
+
+    const res = await h.handler(req, '%40foo%2Fbar-lib', '8%2E1%2E4%2D1');
+    const result = await pipeInto(res.stream);
+
+    t.equal(res.statusCode, 200, 'should respond with expected status code');
+    t.equal(result, 'payload', 'should be possible to retrieve a payload when handlers values is URL encoded');
+    t.end();
+});

--- a/test/handlers/map.put.js
+++ b/test/handlers/map.put.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { PassThrough } = require('stream');
+const FormData = require('form-data');
+const path = require('path');
+const tap = require('tap');
+const fs = require('fs');
+
+const Handler = require('../../lib/handlers/map.put.js');
+const Sink = require('../../lib/sinks/test');
+
+const FIXTURE_MAP = path.resolve(__dirname, '../../fixtures/import-map.json');
+
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('map.put() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    const h = new Handler({ sink });
+
+    const formData = new FormData();
+    formData.append('map', fs.createReadStream(FIXTURE_MAP));
+
+    const headers = formData.getHeaders();
+    const req = new Request({ headers });
+    formData.pipe(req);
+
+    const res = await h.handler(req, 'anton', '%40foo%2Fbar-lib', '8%2E1%2E4%2D1');
+
+    t.equal(res.statusCode, 303, 'should respond with expected status code');
+    t.equal(res.location, '/map/@foo/bar-lib/8.1.4-1', '.location should be decoded');
+    t.end();
+});

--- a/test/handlers/pkg.get.js
+++ b/test/handlers/pkg.get.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { Writable, PassThrough, pipeline } = require('stream');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/pkg.get.js');
+const Sink = require('../../lib/sinks/test');
+
+const pipeInto = (...streams) => new Promise((resolve, reject) => {
+    const buffer = [];
+
+    const to = new Writable({
+        objectMode: false,
+        write(chunk, encoding, callback) {
+            buffer.push(chunk);
+            callback();
+        },
+    });
+
+    pipeline(...streams, to, error => {
+        if (error) return reject(error);
+        const str = buffer.join('').toString();
+        return resolve(str);
+    });
+})
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('pkg.get() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/pkg/@foo/bar-lib/8.1.4-1/foo/main.js', 'payload');
+
+    const h = new Handler({ sink });
+    const req = new Request();
+
+    const res = await h.handler(req, 'pkg', '%40foo%2Fbar-lib', '8%2E1%2E4%2D1', '%2Ffoo%2Fmain.js');
+    const result = await pipeInto(res.stream);
+
+    t.equal(res.statusCode, 200, 'should respond with expected status code');
+    t.equal(result, 'payload', 'should be possible to retrieve a payload when handlers values is URL encoded');
+    t.end();
+});

--- a/test/handlers/pkg.log.js
+++ b/test/handlers/pkg.log.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { Writable, PassThrough, pipeline } = require('stream');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/pkg.log.js');
+const Sink = require('../../lib/sinks/test');
+
+const pipeInto = (...streams) => new Promise((resolve, reject) => {
+    const buffer = [];
+
+    const to = new Writable({
+        objectMode: false,
+        write(chunk, encoding, callback) {
+            buffer.push(chunk);
+            callback();
+        },
+    });
+
+    pipeline(...streams, to, error => {
+        if (error) return reject(error);
+        const str = buffer.join('').toString();
+        return resolve(str);
+    });
+})
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('pkg.log() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/pkg/@foo/bar-lib/8.1.4-1.package.json', 'payload');
+
+    const h = new Handler({ sink });
+    const req = new Request();
+
+    const res = await h.handler(req, 'pkg', '%40foo%2Fbar-lib', '8%2E1%2E4%2D1');
+    const result = await pipeInto(res.stream);
+
+    t.equal(res.statusCode, 200, 'should respond with expected status code');
+    t.equal(result, 'payload', 'should be possible to retrieve a payload when handlers values is URL encoded');
+    t.end();
+});

--- a/test/handlers/pkg.put.js
+++ b/test/handlers/pkg.put.js
@@ -67,6 +67,24 @@ tap.test('pkg.put() - Successful upload of .tar file', async (t) => {
     t.end();
 });
 
+tap.test('pkg.put() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    const h = new Handler({ sink });
+
+    const formData = new FormData();
+    formData.append('package', fs.createReadStream(FIXTURE_TAR));
+
+    const headers = formData.getHeaders();
+    const req = new Request({ headers });
+    formData.pipe(req);
+
+    const res = await h.handler(req, 'anton', 'pkg', '%40foo%2Fbar-lib', '8%2E1%2E4%2D1');
+
+    t.equal(res.statusCode, 303, 'should respond with expected status code');
+    t.equal(res.location, '/pkg/@foo/bar-lib/8.1.4-1', '.location should be decoded');
+    t.end();
+});
+
 tap.test('pkg.put() - Successful upload of .tar.gz file', async (t) => {
     const sink = new Sink();
     const h = new Handler({ sink });

--- a/test/handlers/versions.get.js
+++ b/test/handlers/versions.get.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { Writable, PassThrough, pipeline } = require('stream');
+const tap = require('tap');
+
+const Handler = require('../../lib/handlers/versions.get.js');
+const Sink = require('../../lib/sinks/test');
+
+const pipeInto = (...streams) => new Promise((resolve, reject) => {
+    const buffer = [];
+
+    const to = new Writable({
+        objectMode: false,
+        write(chunk, encoding, callback) {
+            buffer.push(chunk);
+            callback();
+        },
+    });
+
+    pipeline(...streams, to, error => {
+        if (error) return reject(error);
+        const str = buffer.join('').toString();
+        return resolve(str);
+    });
+})
+
+const Request = class Request extends PassThrough {
+    constructor ({
+        headers = {}
+    } = {}) {
+        super();
+        this.headers = {host: 'localhost', ...headers};
+    }
+}
+
+tap.test('versions.get() - URL parameters is URL encoded', async (t) => {
+    const sink = new Sink();
+    sink.set('/local/pkg/@foo/bar-lib/versions.json', 'payload');
+
+    const h = new Handler({ sink });
+    const req = new Request();
+
+    const res = await h.handler(req, 'pkg', '%40foo%2Fbar-lib');
+    const result = await pipeInto(res.stream);
+
+    t.equal(res.statusCode, 200, 'should respond with expected status code');
+    t.equal(result, 'payload', 'should be possible to retrieve a payload when handlers values is URL encoded');
+    t.end();
+});

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const tap = require('tap');
+const utils = require('../../lib/utils/utils');
+
+tap.test('utils.decodeUriComponent()', (t) => {
+    t.equals(utils.decodeUriComponent('%40foo%2Fbar'), '@foo/bar', 'should decode URI encodings');
+    t.equals(utils.decodeUriComponent('8%2E1%2E4%2D1'), '8.1.4-1', 'should decode URI encodings');	
+    t.equals(utils.decodeUriComponent(undefined), undefined, 'should keep a undefined value as undefined');
+    t.equals(utils.decodeUriComponent(undefined), undefined, 'should keep a null value as null');
+    t.end();
+});


### PR DESCRIPTION
This decodes URL encoded URL parameters. 

For the record; When using the client directly against the server URL params with characters such a `@` is handled without any encoding / decoding. This was first discovered when the server run behind a HTTP cache which seems to encode such characters.