### PR TITLE
fix: Expose the internal test sink

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,6 +10,7 @@ import PkgPut from './handlers/pkg.put.js';
 import MapGet from './handlers/map.get.js';
 import MapPut from './handlers/map.put.js';
 
+import TEST from './sinks/test.js';
 import MEM from './sinks/mem.js';
 import FS from './sinks/fs.js';
 
@@ -31,6 +32,7 @@ const http = {
 };
 
 const sink = {
+    TEST,
     MEM,
     FS,
 };


### PR DESCRIPTION
Currently the `@eik/service` is using the internal test sink but its referencing it by dotting into the `node_folder`. This is brittle and should not be done and is also causing the [following lint error](https://github.com/eik-lib/service/pull/300) in the `@eik/service` module:

```sh
Error:   10:18  error  Relative import from another package is not allowed. Use `@eik/core/lib/sinks/test.js` instead of `../node_modules/@eik/core/lib/sinks/test.js`  import/no-relative-packages
```
This exposes the test sink in the same way as we are exposing the file system and memory sink.