### PR TITLE
fix: Removed duplicate logger

### DIFF
--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -22,7 +22,6 @@ const MapGet = class MapGet {
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
-
         this._metrics = new Metrics();
         this._histogram = this._metrics.histogram({
             name: 'eik_core_map_get_handler',

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -31,7 +31,6 @@ const MapPut = class MapPut {
         this._cacheControl = cacheControl;
         this._sink = sink;
         this._log = abslog(logger);
-        this._log = abslog(logger);
         this._metrics = new Metrics();
         this._histogram = this._metrics.histogram({
             name: 'eik_core_map_put_handler',

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -23,7 +23,6 @@ const PkgGet = class PkgGet {
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
-
         this._metrics = new Metrics();
         this._histogram = this._metrics.histogram({
             name: 'eik_core_pkg_get_handler',

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -22,7 +22,6 @@ const VersionsGet = class VersionsGet {
         this._sink = sink;
         this._etag = etag || config.etag;
         this._log = abslog(logger);
-
         this._metrics = new Metrics();
         this._histogram = this._metrics.histogram({
             name: 'eik_core_versions_get_handler',


### PR DESCRIPTION
One handler had a duplicate logger defined. Also cleaned out some whitespace.