### PR TITLE
feat: Add plugin API

### DIFF
--- a/lib/classes/http-incoming.js
+++ b/lib/classes/http-incoming.js
@@ -1,3 +1,5 @@
+import { validators } from '@eik/common';
+
 /**
  * A bearer object to hold misc data through a http
  * request / response cyclus.
@@ -26,14 +28,28 @@ const HttpIncoming = class HttpIncoming {
 
         this._request = request;
         this._headers = request ? request.headers : {};
+        
+        this._handle = '';
+    }
+
+    set version(value) {
+        this._version = validators.version(value);
     }
 
     get version() {
         return this._version;
     }
 
+    set extras(value) {
+        this._extras = validators.extra(value);
+    }
+
     get extras() {
         return this._extras;
+    }
+
+    set author(value) {
+        this._author = value;
     }
 
     get author() {
@@ -44,12 +60,24 @@ const HttpIncoming = class HttpIncoming {
         return this._alias;
     }
 
+    set name(value) {
+        this._name = validators.name(value);
+    }
+
     get name() {
         return this._name;
     }
 
+    set type(value) {
+        this._type = validators.type(value);
+    }
+
     get type() {
         return this._type;
+    }
+
+    set org(value) {
+        this._org = value;
     }
 
     get org() {
@@ -62,6 +90,14 @@ const HttpIncoming = class HttpIncoming {
 
     get headers() {
         return this._headers;
+    }
+
+    set handle(value) {
+        this._handle = value;
+    }
+
+    get handle() {
+        return this._handle;
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/classes/plugin-demo-a.js
+++ b/lib/classes/plugin-demo-a.js
@@ -1,0 +1,38 @@
+import Plugin from './plugin.js';
+
+const PluginDemoA = class PluginDemoA extends Plugin {
+    constructor({
+        name = '',
+    } = {}) {
+        super();
+        this._name = name;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    onRequestStart(incoming) {
+        if (incoming.handle !== 'put:pkg:version') {
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            // console.log('PLUGIN A START', this._name, incoming.type, 'pkg:put:start');
+            resolve(incoming);
+        });
+    }
+
+    onRequestEnd(incoming, outgoing) {
+        return new Promise((resolve, reject) => {
+            // console.log('PLUGIN A END', this._name, incoming.type, 'pkg:put:end');
+            resolve(incoming);
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PluginDemoA';
+    }
+}
+
+export default PluginDemoA;

--- a/lib/classes/plugin-demo-b.js
+++ b/lib/classes/plugin-demo-b.js
@@ -1,0 +1,31 @@
+import Plugin from './plugin.js';
+
+const PluginDemoB = class PluginDemoB extends Plugin {
+    constructor({
+        name = '',
+    } = {}) {
+        super();
+        this._name = name;
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    onRequestStart(incoming) {
+        if (incoming.handle !== 'put:pkg:version') {
+            return false;
+        }
+
+        return new Promise((resolve, reject) => {
+            // console.log('PLUGIN B START', this._name, incoming.type, 'pkg:put:start');
+            resolve(incoming);
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PluginDemoB';
+    }
+}
+
+export default PluginDemoB;

--- a/lib/classes/plugin.js
+++ b/lib/classes/plugin.js
@@ -1,0 +1,26 @@
+import abslog from 'abslog';
+
+const Plugin = class Plugin {
+    constructor({
+        logger,
+    } = {}) {
+        this._log = abslog(logger);
+    }
+
+    onRequestStart() {
+        return undefined;
+    }
+
+    onRequestEnd() {
+        return undefined;
+    }
+
+    healthcheck() {
+        return undefined;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Plugin';
+    }
+}
+export default Plugin;

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -1,4 +1,3 @@
-import { validators } from '@eik/common';
 import originalUrl from 'original-url';
 import HttpError from 'http-errors';
 import abslog from 'abslog';
@@ -6,6 +5,7 @@ import Metrics from '@metrics/client';
 
 import { createFilePathToAsset } from '../utils/path-builders-fs.js';
 import { decodeUriComponent } from '../utils/utils.js';
+import HttpIncoming from '../classes/http-incoming.js';
 import HttpOutgoing from '../classes/http-outgoing.js';
 import Asset from '../classes/asset.js';
 import config from '../utils/defaults.js';
@@ -14,6 +14,7 @@ const PkgGet = class PkgGet {
     constructor({
         organizations,
         cacheControl,
+        plugins,
         logger,
         sink,
         etag,
@@ -45,6 +46,7 @@ const PkgGet = class PkgGet {
             ],
         });
         this._orgRegistry = new Map(this._organizations);
+        this._plugins = plugins || [];
     }
 
     get metrics() {
@@ -53,16 +55,15 @@ const PkgGet = class PkgGet {
 
     async handler(req, type, name, version, extra) {
         const end = this._histogram.timer();
-
-        const pVersion = decodeUriComponent(version);
-        const pExtra = decodeUriComponent(extra);
-        const pName = decodeUriComponent(name);
+        const incoming = new HttpIncoming(req);
+        incoming.handle = `put:${type}:version`;
 
         try {
-            validators.version(pVersion);
-            validators.extra(pExtra);
-            validators.name(pName);
-            validators.type(type);
+            incoming.version = decodeUriComponent(version);
+            incoming.extras = decodeUriComponent(extra);
+            incoming.name = decodeUriComponent(name);
+            incoming.type = type;
+
         } catch (error) {
             this._log.debug(`pkg:get - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
@@ -71,30 +72,51 @@ const PkgGet = class PkgGet {
         }
 
         const url = originalUrl(req);
-        const org = this._orgRegistry.get(url.hostname);
+        incoming.org = this._orgRegistry.get(url.hostname);
 
-        if (!org) {
+        if (!incoming.org) {
             this._log.info(`pkg:get - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
+
+
+        // Run On Request Start plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginStart = this._plugins.map((plugin) => plugin.onRequestStart(incoming)).filter(plugin => plugin !== undefined);
+    
+            if (pluginStart.length !== 0) {
+                try {
+                    await Promise.all(pluginStart);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request start exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
         const asset = new Asset({
-            pathname: pExtra,
-            version: pVersion,
-            name: pName,
-            type,
-            org,
+            pathname: incoming.extras,
+            version: incoming.version,
+            name: incoming.name,
+            type: incoming.type,
+            org: incoming.org,
         });
 
         const path = createFilePathToAsset(asset);
 
+        const outgoing = new HttpOutgoing();
+        outgoing.cacheControl = this._cacheControl;
+        outgoing.mimeType = asset.mimeType;
+
         try {
             const file = await this._sink.read(path);
-            const outgoing = new HttpOutgoing();
-            outgoing.cacheControl = this._cacheControl;
-            outgoing.mimeType = asset.mimeType;
 
             if (this._etag) {
                 outgoing.etag = file.etag;
@@ -111,17 +133,37 @@ const PkgGet = class PkgGet {
                 outgoing.stream = file.stream;
             }
 
-            this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
-
-            end({ labels: { status: outgoing.statusCode, type } });
-
-            return outgoing;
         } catch (error) {
             this._log.debug(`pkg:get - Asset not found - Pathname: ${path}`);
             const e = new HttpError.NotFound();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
+
+
+        
+        // Run On Request End plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginEnd = this._plugins.map((plugin) => plugin.onRequestEnd(incoming, outgoing)).filter(plugin => plugin !== undefined);
+    
+            if (pluginEnd.length !== 0) {
+                try {
+                    await Promise.all(pluginEnd);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request end exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
+        this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
+
+        end({ labels: { status: outgoing.statusCode, type } });
+        return outgoing;
     }
 };
 export default PkgGet;

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -1,4 +1,3 @@
-import { validators } from '@eik/common';
 import originalUrl from 'original-url';
 import HttpError from 'http-errors';
 import abslog from 'abslog';
@@ -6,6 +5,7 @@ import Metrics from '@metrics/client';
 
 import { createFilePathToPackage } from '../utils/path-builders-fs.js';
 import { decodeUriComponent } from '../utils/utils.js';
+import HttpIncoming from '../classes/http-incoming.js';
 import HttpOutgoing from '../classes/http-outgoing.js';
 import config from '../utils/defaults.js';
 
@@ -13,6 +13,7 @@ const PkgLog = class PkgLog {
     constructor({
         organizations,
         cacheControl,
+        plugins,
         logger,
         sink,
         etag,
@@ -43,6 +44,7 @@ const PkgLog = class PkgLog {
             ],
         });
         this._orgRegistry = new Map(this._organizations);
+        this._plugins = plugins || [];
     }
 
     get metrics() {
@@ -51,14 +53,13 @@ const PkgLog = class PkgLog {
 
     async handler(req, type, name, version) {
         const end = this._histogram.timer();
-
-        const pVersion = decodeUriComponent(version);
-        const pName = decodeUriComponent(name);
+        const incoming = new HttpIncoming(req);
+        incoming.handle = `get:${type}:log`;
 
         try {
-            validators.version(pVersion);
-            validators.name(pName);
-            validators.type(type);
+            incoming.version = decodeUriComponent(version);
+            incoming.name = decodeUriComponent(name);
+            incoming.type = type;
         } catch (error) {
             this._log.debug(`pkg:log - Validation failed - ${error.message}`);
             const e = new HttpError.NotFound();
@@ -67,22 +68,43 @@ const PkgLog = class PkgLog {
         }
 
         const url = originalUrl(req);
-        const org = this._orgRegistry.get(url.hostname);
+        incoming.org = this._orgRegistry.get(url.hostname);
 
-        if (!org) {
+        if (!incoming.org) {
             this._log.info(`pkg:log - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
-        const path = createFilePathToPackage({ org, type, name: pName, version: pVersion });
+
+
+        // Run On Request Start plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginStart = this._plugins.map((plugin) => plugin.onRequestStart(incoming)).filter(plugin => plugin !== undefined);
+    
+            if (pluginStart.length !== 0) {
+                try {
+                    await Promise.all(pluginStart);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request start exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
+        const path = createFilePathToPackage(incoming);
+
+        const outgoing = new HttpOutgoing();
+        outgoing.cacheControl = this._cacheControl;
+        outgoing.mimeType = 'application/json';
 
         try {
             const file = await this._sink.read(path);
-            const outgoing = new HttpOutgoing();
-            outgoing.cacheControl = this._cacheControl;
-            outgoing.mimeType = 'application/json';
 
             if (this._etag) {
                 outgoing.etag = file.etag;
@@ -98,18 +120,37 @@ const PkgLog = class PkgLog {
                 outgoing.statusCode = 200;
                 outgoing.stream = file.stream;
             }
-
-            this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
-
-            end({ labels: { status: outgoing.statusCode, type } });
-
-            return outgoing;
         } catch (error) {
-            this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
+            this._log.debug(`pkg:log - Package log not found - Pathname: ${path}`);
             const e = new HttpError.NotFound();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
+
+        this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
+
+
+
+        // Run On Request End plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginEnd = this._plugins.map((plugin) => plugin.onRequestEnd(incoming, outgoing)).filter(plugin => plugin !== undefined);
+    
+            if (pluginEnd.length !== 0) {
+                try {
+                    await Promise.all(pluginEnd);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request end exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
+        end({ labels: { status: outgoing.statusCode, type } });
+        return outgoing;
     }
 };
 export default PkgLog;

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -1,4 +1,3 @@
-import { validators } from '@eik/common';
 import originalUrl from 'original-url';
 import HttpError from 'http-errors';
 import Metrics from '@metrics/client';
@@ -24,6 +23,7 @@ const PkgPut = class PkgPut {
         pkgMaxFileSize,
         organizations,
         cacheControl,
+        plugins,
         logger,
         sink,
     } = {}) {
@@ -59,6 +59,8 @@ const PkgPut = class PkgPut {
             legalFiles: ['package'],
             sink: this._sink,
         });
+
+        this._plugins = plugins || [];
     }
 
     get metrics() {
@@ -146,16 +148,14 @@ const PkgPut = class PkgPut {
     }
 
     async handler(req, user, type, name, version) {
-
         const end = this._histogram.timer();
-
-        const pVersion = decodeUriComponent(version);
-        const pName = decodeUriComponent(name);
+        const incoming = new HttpIncoming(req);
+        incoming.handle = `put:${type}:version`;
 
         try {
-            validators.version(pVersion);
-            validators.name(pName);
-            validators.type(type);
+            incoming.version = decodeUriComponent(version);
+            incoming.name = decodeUriComponent(name);
+            incoming.type = type;
         } catch (error) {
             this._log.info(`pkg:put - Validation failed - ${error.message}`);
             const e = new HttpError.BadRequest();
@@ -164,39 +164,51 @@ const PkgPut = class PkgPut {
         }
 
         const url = originalUrl(req);
-        const org = this._orgRegistry.get(url.hostname);
+        incoming.org = this._orgRegistry.get(url.hostname);
 
-        if (!org) {
+        if (!incoming.org) {
             this._log.info(`pkg:put - Hostname does not match a configured organization - ${url.hostname}`);
             const e = new HttpError.InternalServerError();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
-        const author = new Author(user);
-
-        const incoming = new HttpIncoming(req, {
-            version: pVersion,
-            author,
-            type,
-            name: pName,
-            org,
-        });
+        incoming.author = new Author(user);
 
         const versionExists = await this._readVersion(incoming);
 
         if (versionExists) {
             this._log.info(
-                `pkg:put - Semver version already exists for the package - Org: ${org} - Name: ${pName} - Version: ${pVersion}`,
+                `pkg:put - Semver version already exists for the package - Org: ${incoming.org} - Name: ${incoming.name} - Version: ${incoming.version}`,
             );
             const e = new HttpError.Conflict();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }
 
+
+
+        // Run On Request Start plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginStart = this._plugins.map((plugin) => plugin.onRequestStart(incoming)).filter(plugin => plugin !== undefined);
+    
+            if (pluginStart.length !== 0) {
+                try {
+                    await Promise.all(pluginStart);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request start exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
         const versions = await this._readVersions(incoming);
         const pkg = await this._parser(incoming);
-        versions.setVersion(pVersion, pkg.integrity);
+        versions.setVersion(incoming.version, pkg.integrity);
 
         try {
             await this._writeVersions(incoming, versions);
@@ -211,8 +223,27 @@ const PkgPut = class PkgPut {
         outgoing.statusCode = 303;
         outgoing.location = createURIPathToPkgLog(pkg);
 
-        end({ labels: { status: outgoing.statusCode, type } });
 
+
+        // Run On Request End plugin methods
+        if (this._plugins.length !== 0) {
+            const pluginEnd = this._plugins.map((plugin) => plugin.onRequestEnd(incoming, outgoing)).filter(plugin => plugin !== undefined);
+    
+            if (pluginEnd.length !== 0) {
+                try {
+                    await Promise.all(pluginEnd);
+                } catch (error) {
+                    this._log.info(`pkg:put - A plugin errored during on request end exection - ${error.message}`);
+                    const e = new HttpError.InternalServerError();
+                    end({ labels: { success: false, status: e.status, type } });
+                    throw e;
+                }
+            }
+        }
+
+
+
+        end({ labels: { status: outgoing.statusCode, type } });
         return outgoing;
     }
 };


### PR DESCRIPTION
# Add plugin API

This is a first draft on a plugin API for the Eik server and is intended at this stage to be the base for discussion.

## Why a plugin API? 

There are currently a couple of ideas floating around where we would like to be able to tap into the routes of the REST API and run operations against third party systems. This might best be described by an example:

The Eik server should always have a http cache in front of it. We do not want to bind Eik to a specific http cache so what http cache one put in front of the Eik server can be anything. Having a http cache in front of the Eik server adds complexity in terms of files which have been read do in theory live two places; in the storage of the Eik server and in the http cache.

Currently the Eik server does not provide an http endpoint to delete files and this is mostly due to the fact that we do not really want to delete files on Eik, but there are corner cases where we have too delete a file. So, we do want to add an http endpoint for deleting files. Though, the problem with adding a delete endpoint today is that we're only able to delete the files in the storage of the Eik server. Today we have no way to also purge (delete) the same files from the http cache which live in front of the Eik server since that http cache can be anything.

With a pluging API we can implement a purge plugin suited to purge files in the http cache server one have chosen to put in front of the Eik server (if the http cache has such a feature) and plug that into the server.

## Some Eik core concepts

In the Eik server there are a couple of key components and concepts we use in all http endpoints which is handy to know about:

- When a requests come into a http endpoint, we sanitize and parse out a set of values about the request. These values together with the raw request object is set on a `HttpIncoming` object.
- The `HttpIncoming` object is then handed over to a parser. Parser's are the part which does the  unique work for each route. Depending on the route they perform stuff like extracting uploaded files and saving them in the storage, load a file from the storage and serve it, etc, etc,
- When a parser is done a `HttpOutgoing` object is created and filled with values from the operations the parser did. The `HttpOutgoing` object is then used to form a http response of the http endpoint.

## Initial plugin thoughts

These are some of the initial thought of the features and limitations of a plugin:

- Plugins must be bound to http endpoints and not the underlying implementation. The reason for this is because we do ex use the same underlying implementation for endpoints under both the `npm` and `pkg` namespace. In other words, a plugin should be able to run one set of logic on a endpoint under the `npm` namespace and a different set of logic on a endpoint under the `pkg` namespace despite the fact that the Eik server uses the same code for both namespaces.
- Plugins should be able to hook into multiple steps of the life cycle of a request.
- Its not the role of a plugin to alter the input or output of a request.
- Plugins should be self contained and not exchange data between each other. 
- Plugins should be executed async and in paralell for each step they are hooked into.

Please feel free to question these thought!

## How does this work?

The current implementation is so that there is a registry of registered plugins. A plugin is a object which has a set of methods where each method is intended to be on different locations in the request cycle plus some other utility methods. In this POC one can hook into the start and end of the request cycle but its also possible to make hooks run on ex when a file is extracted form a uploaded tar. 

A plugin looks something like this:

```js
import Plugin from './plugin.js';

const PluginCustom = class PluginCustom extends Plugin {
    constructor() {
        super();
    }

    onRequestStart(incoming) {
        if (incoming.handle !== 'put:pkg:version') {
            return;
        }

        return new Promise((resolve, reject) => {
            // do some stuff
            resolve();
        });
    }

    onRequestEnd(incoming, outgoing) {
        return new Promise((resolve, reject) => {
            // do something else
            resolve();
        });
    }

    get [Symbol.toStringTag]() {
        return 'PluginCustom';
    }
}
```

Each hook in the life cycle of a request will execute the associated method in all the plugins in the registry in parallel. Each method should always be handed `HttpIncoming` as the first argument and possibly other more specific arguments depending on where one are in the request life cycle. Ex; if there is a hook for each extracted file in a tar, this hook should probably provide the meta data object for that file as an argument to this hook.

Inside each method its then possible to check the `.handle` property of `HttpIncoming` to filter on what API and HTTP method one run an operation.

This does also follow the same approach as we do in the sinks where there is a interface class the plugin must extend upon. This is there to secure that all methods in a plugin is present (but just returns nothing) making it possible to just implement the hooks in the request life cycle one want to do some logic in.

In other words; a plugin which only does something on the start of a request looks like so:

```js
import Plugin from './plugin.js';

const PluginCustom = class PluginCustom extends Plugin {
    constructor() {
        super();
    }

    onRequestStart(incoming) {
        if (incoming.handle !== 'put:pkg:version') {
            return;
        }

        return new Promise((resolve, reject) => {
            // do some stuff
            resolve();
        });
    }

    get [Symbol.toStringTag]() {
        return 'PluginCustom';
    }
}
```

The plugin interface should be published as an independent module in the same way as the interface for the sink.