### PR TITLE
fix: change response code to bad request for unconfigured hostname

### DIFF
--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -78,7 +78,7 @@ const AliasDel = class AliasDel {
 
         if (!org) {
             this._log.info(`alias:del - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -72,7 +72,7 @@ const AliasGet = class AliasGet {
 
         if (!org) {
             this._log.info(`alias:get - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -169,7 +169,7 @@ const AliasPost = class AliasPost {
 
         if (!org) {
             this._log.info(`alias:post - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -168,7 +168,7 @@ const AliasPut = class AliasPut {
 
         if (!org) {
             this._log.info(`alias:put - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/auth.post.js
+++ b/lib/handlers/auth.post.js
@@ -84,7 +84,7 @@ const AuthPost = class AuthPost {
 
         if (!org) {
             this._log.info(`auth:post - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type: 'auth' } });
             throw e;
         }

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -70,7 +70,7 @@ const MapGet = class MapGet {
 
         if (!org) {
             this._log.info(`map:get - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -187,7 +187,7 @@ const MapPut = class MapPut {
 
         if (!org) {
             this._log.info(`map:put - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type: 'map' } });
             throw e;
         }

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -74,7 +74,7 @@ const PkgGet = class PkgGet {
 
         if (!org) {
             this._log.info(`pkg:get - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -71,7 +71,7 @@ const PkgLog = class PkgLog {
 
         if (!org) {
             this._log.info(`pkg:log - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -168,7 +168,7 @@ const PkgPut = class PkgPut {
 
         if (!org) {
             this._log.info(`pkg:put - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -71,7 +71,7 @@ const VersionsGet = class VersionsGet {
 
         if (!org) {
             this._log.info(`pkg:latest - Hostname does not match a configured organization - ${url.hostname}`);
-            const e = new HttpError.InternalServerError();
+            const e = new HttpError.BadRequest();
             end({ labels: { success: false, status: e.status, type } });
             throw e;
         }


### PR DESCRIPTION
Being the internet, folks who probe the server with an invalid hostname shouldn't raise 500 error alarms in monitoring.