### PR TITLE
fix: add some logging in case archive parsing fails

### DIFF
--- a/lib/multipart/parser.js
+++ b/lib/multipart/parser.js
@@ -133,6 +133,9 @@ const MultipartParser = class MultipartParser {
 
             pipeline(file, extract, (error) => {
                 if (error) {
+                    this._log.info(`multipart - Uploaded package could not be extracted properly - Field: ${fieldname} - Filename: ${filename}`)
+                    this._log.trace(error);
+
                     switch (error.code) {
                         case 'TAR_BAD_ARCHIVE':
                         case 'TAR_ABORT':


### PR DESCRIPTION
We've seen some errors for archives with a large number of files, but without logging we're guessing a bit more than we'd like.

Fixes #418