### PR TITLE
fix: make healthcheck logging less verbose by default

### DIFF
--- a/lib/utils/healthcheck.js
+++ b/lib/utils/healthcheck.js
@@ -74,7 +74,7 @@ const HealthCheck = class HealthCheck {
 	}
 
 	async check() {
-		this._log.info(
+		this._log.debug(
 			`Sink health check started - testing with file ${this._name}`,
 		);
 
@@ -120,7 +120,7 @@ const HealthCheck = class HealthCheck {
 			throw new Error("File exist in sink");
 			// eslint-disable-next-line no-unused-vars
 		} catch (error) {
-			this._log.info("Sink health check ended successfully. Sink is healthy");
+			this._log.debug("Sink health check ended successfully. Sink is healthy");
 		}
 
 		return true;


### PR DESCRIPTION
Open for discussing this. Another option is of course to increase the loglevel to WARN if you think this is too verbose.
