### PR TITLE
fix: end timer on stream end or error 

### DIFF
--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -96,11 +96,18 @@ const MapGet = class MapGet {
 			} else {
 				outgoing.statusCode = 200;
 				outgoing.stream = file.stream;
+
+				outgoing.stream.on("error", (err) => {
+					this._log.info(`map:get - File stream error - ${err}`);
+					end({ labels: { success: false, status: 503, type: "map" } });
+				});
+
+				outgoing.stream.on("end", () => {
+					end({ labels: { status: outgoing.statusCode, type: "map" } });
+				});
 			}
 
 			this._log.debug(`map:get - Import map found - Pathname: ${path}`);
-
-			end({ labels: { status: outgoing.statusCode, type: "map" } });
 
 			return outgoing;
 			// eslint-disable-next-line no-unused-vars

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -105,11 +105,15 @@ const PkgGet = class PkgGet {
 			} else {
 				outgoing.statusCode = 200;
 				outgoing.stream = file.stream;
+				outgoing.stream.on("end", () => {
+					console.log("FINISH " + performance.now());
+				});
 			}
 
 			this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
 
 			end({ labels: { status: outgoing.statusCode, type } });
+			console.log("END " + performance.now());
 
 			return outgoing;
 			// eslint-disable-next-line no-unused-vars

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -105,15 +105,18 @@ const PkgGet = class PkgGet {
 			} else {
 				outgoing.statusCode = 200;
 				outgoing.stream = file.stream;
+
+				outgoing.stream.on("error", (err) => {
+					this._log.info(`pkg:get - File stream error - ${err}`);
+					end({ labels: { success: false, status: 503, type } });
+				});
+
 				outgoing.stream.on("end", () => {
-					console.log("FINISH " + performance.now());
+					end({ labels: { status: outgoing.statusCode, type } });
 				});
 			}
 
 			this._log.debug(`pkg:get - Asset found - Pathname: ${path}`);
-
-			end({ labels: { status: outgoing.statusCode, type } });
-			console.log("END " + performance.now());
 
 			return outgoing;
 			// eslint-disable-next-line no-unused-vars

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -98,11 +98,18 @@ const PkgLog = class PkgLog {
 			} else {
 				outgoing.statusCode = 200;
 				outgoing.stream = file.stream;
+
+				outgoing.stream.on("error", (err) => {
+					this._log.info(`pkg:log - File stream error - ${err}`);
+					end({ labels: { success: false, status: 503, type } });
+				});
+
+				outgoing.stream.on("end", () => {
+					end({ labels: { status: outgoing.statusCode, type } });
+				});
 			}
 
 			this._log.debug(`pkg:log - Package log found - Pathname: ${path}`);
-
-			end({ labels: { status: outgoing.statusCode, type } });
 
 			return outgoing;
 			// eslint-disable-next-line no-unused-vars

--- a/lib/handlers/versions.get.js
+++ b/lib/handlers/versions.get.js
@@ -90,11 +90,18 @@ const VersionsGet = class VersionsGet {
 			} else {
 				outgoing.statusCode = 200;
 				outgoing.stream = file.stream;
+
+				outgoing.stream.on("error", (err) => {
+					this._log.info(`pkg:latest - File stream error - ${err}`);
+					end({ labels: { success: false, status: 503, type } });
+				});
+
+				outgoing.stream.on("end", () => {
+					end({ labels: { status: outgoing.statusCode, type } });
+				});
 			}
 
 			this._log.debug(`pkg:latest - Package log found - Pathname: ${path}`);
-
-			end({ labels: { status: outgoing.statusCode, type } });
 
 			return outgoing;
 			// eslint-disable-next-line no-unused-vars

--- a/lib/sinks/test.js
+++ b/lib/sinks/test.js
@@ -13,6 +13,8 @@ const DEFAULT_ROOT_PATH = "/eik";
  * @deprecated Use eik/sink-memory or implement your own. This class will be removed in a future version of core.
  */
 export default class SinkTest extends Sink {
+	readDelay = 0;
+
 	constructor({ rootPath = DEFAULT_ROOT_PATH } = {}) {
 		super();
 		this._rootPath = rootPath;
@@ -193,12 +195,22 @@ export default class SinkTest extends Sink {
 				etag: entry.hash,
 			});
 
+			const readDelay = this.readDelay;
 			file.stream = new Readable({
 				read() {
-					payload.forEach((item) => {
-						this.push(item);
-					});
-					this.push(null);
+					if (readDelay) {
+						setTimeout(() => {
+							payload.forEach((item) => {
+								this.push(item);
+							});
+							this.push(null);
+						}, readDelay);
+					} else {
+						payload.forEach((item) => {
+							this.push(item);
+						});
+						this.push(null);
+					}
 				},
 			});
 

--- a/test/handlers/pkg.get.js
+++ b/test/handlers/pkg.get.js
@@ -33,6 +33,7 @@ const Request = class Request extends PassThrough {
 
 tap.test("pkg.get() - URL parameters is URL encoded", async (t) => {
 	const sink = new Sink();
+	sink.readDelay = 10_000;
 	sink.set("/local/pkg/@foo/bar-lib/8.1.4-1/foo/main.js", "payload");
 
 	const h = new Handler({ sink });


### PR DESCRIPTION
We measure the action as done when the stream is returned, not when the stream itself is finished. This could be misleading.

[See the difference between `END` and `FINISH`](https://github.com/eik-lib/core/actions/runs/17125749161/job/48576899364?pr=503#step:7:429).

```
# Subtest: test/handlers/pkg.get.js
    END 2181.057062
    FINISH 12189.26404
    # Subtest: pkg.get() - URL parameters is URL encoded
        ok 1 - should respond with expected status code
        ok 2 - should be possible to retrieve a payload when handlers values is URL encoded
        1..2
    ok 1 - pkg.get() - URL parameters is URL encoded # time=10025.446ms
    
    1..1
```