### PR TITLE
fix: Improve unpacking files

### DIFF
--- a/lib/multipart/parser.js
+++ b/lib/multipart/parser.js
@@ -93,9 +93,12 @@ const MultipartParser = class MultipartParser {
 									done(item);
 								})
 								.catch((error) => {
-									// Emit an error on busboy instead of rejecting
-									// This will break and terminate the stream stright away
+									// Emit an error on busboy instead of rejecting.
+									// This breaks and terminates the stream straight away.
 									busboy.emit("error", error);
+									// Settle this wrapper Promise so Promise.all(queue)
+									// in the close handler can always complete.
+									done(null);
 								});
 						}),
 					);
@@ -142,6 +145,7 @@ const MultipartParser = class MultipartParser {
 				`multipart - Start extracting package - Field: ${fieldname} - Filename: ${filename}`,
 			);
 
+			const ac = new AbortController();
 			/** @type {Promise<any>[]} */
 			const queue = [];
 
@@ -149,6 +153,7 @@ const MultipartParser = class MultipartParser {
 				this._log.info(
 					`multipart - Uploaded package exceeds legal file size limit - Field: ${fieldname} - Filename: ${filename}`,
 				);
+				ac.abort();
 				file.emit("error", new HttpError.PayloadTooLarge());
 			});
 
@@ -161,7 +166,15 @@ const MultipartParser = class MultipartParser {
 						entry.resume();
 						return;
 					}
-					queue.push(this._persistFile({ incoming, entry }));
+					const persist = this._persistFile({
+						incoming,
+						entry,
+						signal: ac.signal,
+					});
+					// Suppress unhandled rejections from writes aborted due to
+					// an upstream error — they are intentionally abandoned.
+					persist.catch(() => {});
+					queue.push(persist);
 				},
 			});
 
@@ -171,6 +184,8 @@ const MultipartParser = class MultipartParser {
 						`multipart - Uploaded package could not be extracted properly - Field: ${fieldname} - Filename: ${filename}`,
 					);
 					this._log.trace(error);
+
+					ac.abort();
 
 					switch (error.code) {
 						case "TAR_BAD_ARCHIVE":
@@ -201,61 +216,71 @@ const MultipartParser = class MultipartParser {
 	}
 
 	/**
-	 * @param {{ incoming: any, entry: any }} options
+	 * @param {{ incoming: any, entry: any, signal: AbortSignal }} options
 	 */
-	_persistFile({ incoming, entry }) {
-		// eslint-disable-next-line no-async-promise-executor
-		return new Promise(async (resolve, reject) => {
-			const asset = new Asset({
-				pathname: entry.path,
-				version: incoming.version,
-				name: incoming.name,
-				type: incoming.type,
-				org: incoming.org,
-			});
-			asset.size = entry.size;
+	async _persistFile({ incoming, entry, signal }) {
+		const asset = new Asset({
+			pathname: entry.path,
+			version: incoming.version,
+			name: incoming.name,
+			type: incoming.type,
+			org: incoming.org,
+		});
+		asset.size = entry.size;
 
-			const path = createFilePathToAsset(asset);
+		const path = createFilePathToAsset(asset);
 
-			this._log.info(
-				`multipart - Start writing asset to sink - Pathname: ${path}`,
-			);
+		this._log.info(
+			`multipart - Start writing asset to sink - Pathname: ${path}`,
+		);
 
-			try {
-				if (!this._sink) {
-					reject(new Error("No sink configured"));
+		if (!this._sink) {
+			throw new Error("No sink configured");
+		}
+		const writer = await this._sink.write(path, asset.mimeType);
+
+		const integrityStream = ssri.integrityStream({ single: true });
+		let hash = "";
+		integrityStream.once("integrity", (/** @type {any} */ integrity) => {
+			hash = integrity;
+		});
+
+		return new Promise((resolve, reject) => {
+			const onAbort = () => {
+				entry.destroy();
+				integrityStream.destroy();
+				writer.destroy();
+			};
+
+			if (signal.aborted) {
+				onAbort();
+				reject(new Error("Aborted"));
+				return;
+			}
+
+			signal.addEventListener("abort", onAbort, { once: true });
+
+			pipeline(entry, integrityStream, writer, (error) => {
+				signal.removeEventListener("abort", onAbort);
+
+				if (error) {
+					this._log.error(
+						`multipart - Failed writing asset to sink - Pathname: ${path}`,
+					);
+					this._log.trace(error);
+
+					reject(error);
 					return;
 				}
-				const writer = await this._sink.write(path, asset.mimeType);
 
-				const integrityStream = ssri.integrityStream({ single: true });
-				let hash = "";
-				integrityStream.once("integrity", (/** @type {any} */ integrity) => {
-					hash = integrity;
-				});
+				asset.integrity = hash.toString();
 
-				pipeline(entry, integrityStream, writer, (error) => {
-					if (error) {
-						this._log.error(
-							`multipart - Failed writing asset to sink - Pathname: ${path}`,
-						);
-						this._log.trace(error);
+				this._log.info(
+					`multipart - Successfully wrote asset to sink - Pathname: ${path}`,
+				);
 
-						reject(error);
-						return;
-					}
-
-					asset.integrity = hash.toString();
-
-					this._log.info(
-						`multipart - Successfully wrote asset to sink - Pathname: ${path}`,
-					);
-
-					resolve(asset);
-				});
-			} catch (error) {
-				reject(error);
-			}
+				resolve(asset);
+			});
 		});
 	}
 };

--- a/test/handlers/pkg.get.js
+++ b/test/handlers/pkg.get.js
@@ -35,7 +35,6 @@ const Request = class Request extends PassThrough {
 
 test("pkg.get() - URL parameters is URL encoded", async () => {
 	const sink = new Sink();
-	sink.readDelay = 10_000;
 	sink.set("/local/pkg/@foo/bar-lib/8.1.4-1/foo/main.js", "payload");
 
 	const h = new Handler({ sink });

--- a/test/multipart/parser.js
+++ b/test/multipart/parser.js
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import Sink from "@eik/sink-memory";
+import SinkTest from "../../lib/sinks/test.js";
 
 import MultipartParser from "../../lib/multipart/parser.js";
 import HttpIncoming from "../../lib/classes/http-incoming.js";
@@ -15,6 +16,10 @@ const FIXTURE_TAR = new URL("../../fixtures/package.tar", import.meta.url);
 const FIXTURE_BZ2 = new URL("../../fixtures/package.tar.bz2", import.meta.url);
 const FIXTURE_GZ = new URL("../../fixtures/package.tar.gz", import.meta.url);
 const FIXTURE_PKG = new URL("../../fixtures/archive.tgz", import.meta.url);
+const FIXTURE_SMALL_PKG = new URL(
+	"../../fixtures/archive-small.tgz",
+	import.meta.url,
+);
 
 const Request = class Request extends PassThrough {
 	constructor({ headers = {} } = {}) {
@@ -320,5 +325,61 @@ test("Parser() - Request contain file which is too large", async () => {
 		multipart.parse(incoming),
 		HttpError.PayloadTooLarge,
 		"should reject with payload too large error",
+	);
+});
+
+test("Parser() - In-flight sink writes are aborted when file size limit is exceeded", async () => {
+	const sink = new SinkTest();
+	// Delay write() returning its stream so _persistFile calls are guaranteed
+	// to be awaiting when the abort fires. This lets the test distinguish
+	// between writes that were properly aborted (no data in sink) and writes
+	// that completed unchecked (data present in sink).
+	sink.writeDelayResolve = () => 20;
+
+	const multipart = new MultipartParser({
+		// archive-small.tgz is 1,093 bytes — set limit just below so the
+		// file starts being processed before the limit event fires.
+		pkgMaxFileSize: 1000,
+		legalFiles: ["package"],
+		sink,
+	});
+
+	const formData = new FormData();
+	formData.append(
+		"package",
+		new Blob([fs.readFileSync(FIXTURE_SMALL_PKG)], {
+			type: "application/octet-stream",
+		}),
+		"archive-small.tgz",
+	);
+
+	const _response = new Response(formData);
+	const headers = { "content-type": _response.headers.get("content-type") };
+	const req = new Request({ headers });
+	const incoming = new HttpIncoming(req, {
+		version: "1.0.0",
+		author: {},
+		type: "pkg",
+		name: "test-pkg",
+		org: "local",
+	});
+
+	_response.arrayBuffer().then((buf) => req.end(Buffer.from(buf)));
+
+	await assert.rejects(
+		multipart.parse(incoming),
+		HttpError.PayloadTooLarge,
+		"should reject with payload too large error",
+	);
+
+	// Wait longer than writeDelayResolve so that any write() calls that were
+	// not aborted would have had time to return their stream, run the pipeline,
+	// and fire the finish event that commits data to the sink.
+	await new Promise((resolve) => setTimeout(resolve, 100));
+
+	assert.strictEqual(
+		sink.dump().length,
+		0,
+		"should not commit any asset writes to the sink when the upload is aborted",
 	);
 });


### PR DESCRIPTION
Continued work on analyzing Eik.

Some issues found in this module:

## Promise.all() never resolves

When unpacking files from the tar ball we never call `done()` is anything goes wrong. This will cause the `Promise.all()` later on to never resolve (ex; if there is a upload error etc) and content will be kept in memory until GC tries to deal with it.

Fix: Call `done()` on errors too.

## Streams kept open if an error occur

When we unpack a tar file the there is an array with Promises (one promise for each file in the tar ball) we go through and write each file to the storage (sink). When writing a file to the sink (storage) the file goes through 3 streams. If any of these streams fail the extraction of the whole tar should be cancelled but we keep continue to writing files we have in the array of promises after the error. 

Fix; Add a `AbortController` which signals Abortion if any of the streams we pipe files through errors.

## Converted `new Promise` to a plain `async` method in the `_persistFile` method.

Not really a bug, but helps on propagating Promise rejections / thrown errors. The benefit is that we now set up the code in a synchronous order where the method writing to the file storage (sink) become part of the async function body where a thrown exception will become a proper promise rejection.